### PR TITLE
Add new run type "triggered" to distinguish manual DAG runs and triggered runs

### DIFF
--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -159,7 +159,7 @@ class TriggerDagRunOperator(BaseOperator):
         if self.trigger_run_id:
             run_id = str(self.trigger_run_id)
         else:
-            run_id = DagRun.generate_run_id(DagRunType.MANUAL, parsed_execution_date)
+            run_id = DagRun.generate_run_id(DagRunType.TRIGGERED, parsed_execution_date)
 
         try:
             dag_run = trigger_dag(

--- a/airflow/utils/types.py
+++ b/airflow/utils/types.py
@@ -52,6 +52,7 @@ class DagRunType(str, enum.Enum):
     SCHEDULED = "scheduled"
     MANUAL = "manual"
     DATASET_TRIGGERED = "dataset_triggered"
+    TRIGGERED = "triggered"
 
     def __str__(self) -> str:
         return self.value

--- a/airflow/www/static/js/components/RunTypeIcon.tsx
+++ b/airflow/www/static/js/components/RunTypeIcon.tsx
@@ -18,7 +18,7 @@
  */
 
 import React from "react";
-import { MdPlayArrow, MdOutlineSchedule } from "react-icons/md";
+import { MdPlayArrow, MdOutlineSchedule, MdBolt } from "react-icons/md";
 import { RiArrowGoBackFill } from "react-icons/ri";
 import { HiDatabase } from "react-icons/hi";
 
@@ -44,6 +44,8 @@ const DagRunTypeIcon = ({ runType, ...rest }: Props) => {
       return <MdOutlineSchedule style={iconStyle} {...rest} />;
     case "dataset_triggered":
       return <HiDatabase style={iconStyle} {...rest} />;
+    case "triggered":
+      return <MdBolt style={iconStyle} {...rest} />;
     default:
       return null;
   }

--- a/airflow/www/static/js/types/index.ts
+++ b/airflow/www/static/js/types/index.ts
@@ -53,7 +53,12 @@ interface Dag {
 
 interface DagRun {
   runId: string;
-  runType: "manual" | "backfill" | "scheduled" | "dataset_triggered";
+  runType:
+    | "manual"
+    | "backfill"
+    | "scheduled"
+    | "dataset_triggered"
+    | "triggered";
   state: RunState;
   executionDate: string;
   dataIntervalStart: string;

--- a/tests/operators/test_trigger_dagrun.py
+++ b/tests/operators/test_trigger_dagrun.py
@@ -122,7 +122,7 @@ class TestDagRunOperator:
         with create_session() as session:
             dagrun = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).one()
             assert dagrun.external_trigger
-            assert dagrun.run_id == DagRun.generate_run_id(DagRunType.MANUAL, dagrun.execution_date)
+            assert dagrun.run_id == DagRun.generate_run_id(DagRunType.TRIGGERED, dagrun.execution_date)
             self.assert_extra_link(dagrun, task, session)
 
     def test_trigger_dagrun_custom_run_id(self):
@@ -154,7 +154,7 @@ class TestDagRunOperator:
             dagrun = session.query(DagRun).filter(DagRun.dag_id == TRIGGERED_DAG_ID).one()
             assert dagrun.external_trigger
             assert dagrun.execution_date == custom_execution_date
-            assert dagrun.run_id == DagRun.generate_run_id(DagRunType.MANUAL, custom_execution_date)
+            assert dagrun.run_id == DagRun.generate_run_id(DagRunType.TRIGGERED, custom_execution_date)
             self.assert_extra_link(dagrun, task, session)
 
     def test_trigger_dagrun_twice(self):


### PR DESCRIPTION
Add new run type "triggered" to distinguish manual DAG runs and triggered DAG runs (`TriggerDagRunOperator`).

### Justification to introduce a new RunType
Before this improvement, we were prepending the run id with the string "manual" for `TriggerDagRunOperator` as well as manual run (which can be started on UI). This can cause a misunderstanding when we look for the logs and also for the UI. We did not have a way to distinguish **manual runs** and the **triggered runs** (which can be done with `TriggerDagRunOperator`).

To accomplish this, I introduced the followings:
- A new RunType value:
```python3
TRIGGERED = "triggered"
```
- A new icon for UI:
  ```typescript
  import { MdBolt } from "react-icons/md";
  // ...
      case "triggered":
        return <MdBolt style={iconStyle} {...rest} />;
  //...
  ```
  which is look likes the following (in action):
  ![output](https://github.com/VladaZakharova/airflow/assets/5708658/dd93b05b-fd81-4bdd-bffe-4a7b080fde1e)

  > Of course, we can change the icon with another icon that can be more suitable but as a entry point, I selected this one.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
