### PR TITLE
Refactor GKE hooks

### DIFF
--- a/airflow/providers/cncf/kubernetes/operators/pod.py
+++ b/airflow/providers/cncf/kubernetes/operators/pod.py
@@ -771,7 +771,7 @@ class KubernetesPodOperator(BaseOperator):
 
     @deprecated(reason="use `trigger_reentry` instead.", category=AirflowProviderDeprecationWarning)
     def execute_complete(self, context: Context, event: dict, **kwargs):
-        self.trigger_reentry(context=context, event=event)
+        return self.trigger_reentry(context=context, event=event)
 
     def write_logs(self, pod: k8s.V1Pod):
         try:

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -541,6 +541,7 @@ class GKEStartKueueInsideClusterOperator(GoogleCloudBaseOperator):
             impersonation_chain=self.impersonation_chain,
             cluster_url=self._cluster_url,
             ssl_ca_cert=self._ssl_ca_cert,
+            enable_tcp_keepalive=True,
         )
 
     @staticmethod
@@ -743,6 +744,7 @@ class GKEStartPodOperator(KubernetesPodOperator):
             cluster_url=self._cluster_url,
             ssl_ca_cert=self._ssl_ca_cert,
             impersonation_chain=self.impersonation_chain,
+            enable_tcp_keepalive=True,
         )
         return hook
 

--- a/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -147,6 +147,7 @@ class GKEStartPodTrigger(KubernetesPodTrigger):
             ssl_ca_cert=self._ssl_ca_cert,
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
+            enable_tcp_keepalive=True,
         )
 
 

--- a/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
+++ b/tests/providers/google/cloud/hooks/test_kubernetes_engine.py
@@ -508,38 +508,28 @@ class TestGKEPodAsyncHook:
         )
 
     @pytest.mark.asyncio
-    @mock.patch(BASE_STRING.format("_CredentialsToken"))
     @mock.patch(GKE_STRING.format("GKEPodAsyncHook.get_conn"))
     @mock.patch(GKE_STRING.format("async_client.CoreV1Api.read_namespaced_pod"))
-    async def test_get_pod(self, read_namespace_pod_mock, get_conn_mock, mock_token, async_hook):
-        async_hook.get_token = mock.AsyncMock()
-        async_hook.get_token.return_value = mock_token
-
+    async def test_get_pod(self, read_namespace_pod_mock, get_conn_mock, async_hook):
         self.make_mock_awaitable(read_namespace_pod_mock)
 
         await async_hook.get_pod(name=POD_NAME, namespace=POD_NAMESPACE)
 
-        async_hook.get_token.assert_called_once()
-        get_conn_mock.assert_called_once_with(mock_token)
+        get_conn_mock.assert_called_once_with()
         read_namespace_pod_mock.assert_called_with(
             name=POD_NAME,
             namespace=POD_NAMESPACE,
         )
 
     @pytest.mark.asyncio
-    @mock.patch(BASE_STRING.format("_CredentialsToken"))
     @mock.patch(GKE_STRING.format("GKEPodAsyncHook.get_conn"))
     @mock.patch(GKE_STRING.format("async_client.CoreV1Api.delete_namespaced_pod"))
-    async def test_delete_pod(self, delete_namespaced_pod, get_conn_mock, mock_token, async_hook):
-        async_hook.get_token = mock.AsyncMock()
-        async_hook.get_token.return_value = mock_token
-
+    async def test_delete_pod(self, delete_namespaced_pod, get_conn_mock, async_hook):
         self.make_mock_awaitable(delete_namespaced_pod)
 
         await async_hook.delete_pod(name=POD_NAME, namespace=POD_NAMESPACE)
 
-        async_hook.get_token.assert_called_once()
-        get_conn_mock.assert_called_once_with(mock_token)
+        get_conn_mock.assert_called_once_with()
         delete_namespaced_pod.assert_called_with(
             name=POD_NAME,
             namespace=POD_NAMESPACE,
@@ -547,19 +537,14 @@ class TestGKEPodAsyncHook:
         )
 
     @pytest.mark.asyncio
-    @mock.patch(BASE_STRING.format("_CredentialsToken"))
     @mock.patch(GKE_STRING.format("GKEPodAsyncHook.get_conn"))
     @mock.patch(GKE_STRING.format("async_client.CoreV1Api.read_namespaced_pod_log"))
-    async def test_read_logs(self, read_namespaced_pod_log, get_conn_mock, mock_token, async_hook, caplog):
-        async_hook.get_token = mock.AsyncMock()
-        async_hook.get_token.return_value = mock_token
-
+    async def test_read_logs(self, read_namespaced_pod_log, get_conn_mock, async_hook, caplog):
         self.make_mock_awaitable(read_namespaced_pod_log, result="Test string #1\nTest string #2\n")
 
         await async_hook.read_logs(name=POD_NAME, namespace=POD_NAMESPACE)
 
-        async_hook.get_token.assert_called_once()
-        get_conn_mock.assert_called_once_with(mock_token)
+        get_conn_mock.assert_called_once_with()
         read_namespaced_pod_log.assert_called_with(
             name=POD_NAME,
             namespace=POD_NAMESPACE,

--- a/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine.py
+++ b/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine.py
@@ -31,17 +31,19 @@ from airflow.providers.google.cloud.operators.kubernetes_engine import (
     GKEDeleteClusterOperator,
     GKEStartPodOperator,
 )
+from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 DAG_ID = "kubernetes_engine"
 GCP_PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
 
 GCP_LOCATION = "europe-north1-a"
-CLUSTER_NAME = f"cluster-name-test-build-{ENV_ID}"
+CLUSTER_NAME = f"gke-{ENV_ID}".replace("_", "-")
 
 # [START howto_operator_gcp_gke_create_cluster_definition]
 CLUSTER = {"name": CLUSTER_NAME, "initial_node_count": 1}
 # [END howto_operator_gcp_gke_create_cluster_definition]
+
 
 with DAG(
     DAG_ID,
@@ -102,9 +104,9 @@ with DAG(
         location=GCP_LOCATION,
     )
     # [END howto_operator_gke_delete_cluster]
+    delete_cluster.trigger_rule = TriggerRule.ALL_DONE
 
-    create_cluster >> pod_task >> delete_cluster
-    create_cluster >> pod_task_xcom >> delete_cluster
+    create_cluster >> [pod_task, pod_task_xcom] >> delete_cluster
     pod_task_xcom >> pod_task_xcom_result
 
     from tests.system.utils.watcher import watcher

--- a/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_async.py
+++ b/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_async.py
@@ -31,13 +31,14 @@ from airflow.providers.google.cloud.operators.kubernetes_engine import (
     GKEDeleteClusterOperator,
     GKEStartPodOperator,
 )
+from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID")
 DAG_ID = "kubernetes_engine_async"
 GCP_PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
 
 GCP_LOCATION = "europe-north1-a"
-CLUSTER_NAME = f"example-cluster-defer-{ENV_ID}".replace("_", "-")
+CLUSTER_NAME = f"gke-async-{ENV_ID}".replace("_", "-")
 
 CLUSTER = {"name": CLUSTER_NAME, "initial_node_count": 1}
 
@@ -92,7 +93,7 @@ with DAG(
 
     # [START howto_operator_gke_xcom_result_async]
     pod_task_xcom_result = BashOperator(
-        bash_command="echo \"{{ task_instance.xcom_pull('pod_task_xcom')[0] }}\"",
+        bash_command="echo \"{{ task_instance.xcom_pull('pod_task_xcom_async')[0] }}\"",
         task_id="pod_task_xcom_result",
     )
     # [END howto_operator_gke_xcom_result_async]
@@ -106,9 +107,9 @@ with DAG(
         deferrable=True,
     )
     # [END howto_operator_gke_delete_cluster_async]
+    delete_cluster.trigger_rule = TriggerRule.ALL_DONE
 
-    create_cluster >> pod_task >> delete_cluster
-    create_cluster >> pod_task_xcom_async >> delete_cluster
+    create_cluster >> [pod_task, pod_task_xcom_async] >> delete_cluster
     pod_task_xcom_async >> pod_task_xcom_result
 
     from tests.system.utils.watcher import watcher

--- a/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_resource.py
+++ b/tests/system/providers/google/cloud/kubernetes_engine/example_kubernetes_engine_resource.py
@@ -31,13 +31,14 @@ from airflow.providers.google.cloud.operators.kubernetes_engine import (
     GKEDeleteClusterOperator,
     GKEDeleteCustomResourceOperator,
 )
+from airflow.utils.trigger_rule import TriggerRule
 
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 DAG_ID = "kubernetes_engine_resource"
 GCP_PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
 
 GCP_LOCATION = "europe-north1-a"
-CLUSTER_NAME = f"cluster-name-test-build-{ENV_ID}"
+CLUSTER_NAME = f"gke-resource-{ENV_ID}".replace("_", "-")
 CLUSTER = {"name": CLUSTER_NAME, "initial_node_count": 1}
 
 PVC_NAME = "test-pvc-name"
@@ -95,6 +96,7 @@ with DAG(
         name=CLUSTER_NAME,
         project_id=GCP_PROJECT_ID,
         location=GCP_LOCATION,
+        trigger_rule=TriggerRule.ALL_DONE,
     )
 
     create_cluster >> create_resource_task >> delete_resource_task >> delete_cluster


### PR DESCRIPTION
In order to reduce code duplication and high complexity of the implementation, GKE hooks were refactored in this PR:
1. Existing `GKEHook` and `GKEAsyncHook` provide interface to GKE API remain unchanged.
2. The new `GKEKubernetesHook(GoogleBaseHook, KubernetesHook)` was introduced as a replacement for redundant hooks that used to contain duplicated methods that now are simply inherited from `GoogleBaseHook` and `KubernetesHook`:
- GKEDeploymentHook (deprecated)
- GKECustomResourceHook (deprecated)
- GKEPodHook (deprecated)
- GKEJobHook (deprecated)
3. By following the same pattern, the new `GKEKubernetesAsyncHook(GoogleBaseAsyncHook, AsyncKubernetesHook)` was introduced as a replacement for redundant hooks that used to contain duplicated methods that now are simply inherited from `GoogleBaseAsyncHook` and `AsyncKubernetesHook`:
- GKEPodAsyncHook (deprecated)
4. New hooks (GKEKubernetesHook, GKEKubernetesAsyncHook) provide access to the standard Kubernetes API with a GKE authentication.
5. Slightly adjusted system tests (they are all green now).
![system tests](https://github.com/VladaZakharova/airflow/assets/42827971/bf8807a8-43f5-4792-b8bd-8050df722984)
6. Except tiny changes, unit tests remain the same in order to prove stability of the code after refactoring. In the following PR we will disconnect GKE operators from the deprecated hooks, so it will be easy to remove them in the future.