### PR TITLE
Add triggered_by field to DAG Run model to distinguish the source of a trigger

### DIFF
--- a/airflow/api/client/api_client.py
+++ b/airflow/api/client/api_client.py
@@ -19,7 +19,12 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 import httpx
+
+if TYPE_CHECKING:
+    from airflow.utils.types import DagRunTriggeredByType
 
 
 class Client:
@@ -31,7 +36,15 @@ class Client:
         if auth:
             self._session.auth = auth
 
-    def trigger_dag(self, dag_id, run_id=None, conf=None, execution_date=None, replace_microseconds=True):
+    def trigger_dag(
+        self,
+        dag_id,
+        run_id=None,
+        conf=None,
+        execution_date=None,
+        replace_microseconds=True,
+        triggered_by: DagRunTriggeredByType | None = None,
+    ):
         """Create a dag run for the specified dag.
 
         :param dag_id:
@@ -39,6 +52,7 @@ class Client:
         :param conf:
         :param execution_date:
         :param replace_microseconds:
+        :param triggered_by:
         :return:
         """
         raise NotImplementedError()

--- a/airflow/api/client/json_client.py
+++ b/airflow/api/client/json_client.py
@@ -19,9 +19,13 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
 from urllib.parse import urljoin
 
 from airflow.api.client import api_client
+
+if TYPE_CHECKING:
+    from airflow.utils.types import DagRunTriggeredByType
 
 
 class Client(api_client.Client):
@@ -55,7 +59,15 @@ class Client(api_client.Client):
             raise OSError(data.get("error", "Server error"))
         return resp.json()
 
-    def trigger_dag(self, dag_id, run_id=None, conf=None, execution_date=None, replace_microseconds=True):
+    def trigger_dag(
+        self,
+        dag_id,
+        run_id=None,
+        conf=None,
+        execution_date=None,
+        replace_microseconds=True,
+        triggered_by: DagRunTriggeredByType | None = None,
+    ):
         """Trigger a DAG run.
 
         :param dag_id: The ID of the DAG to trigger.
@@ -63,6 +75,7 @@ class Client(api_client.Client):
         :param conf: A dictionary containing configuration data to pass to the DAG run.
         :param execution_date: The execution date for the DAG run, in the format "YYYY-MM-DDTHH:MM:SS".
         :param replace_microseconds: Whether to replace microseconds in the execution date with zeros.
+        :param triggered_by: The entity which triggers the DAG run.
         :return: A message indicating the status of the DAG run trigger.
         """
         endpoint = f"/api/experimental/dags/{dag_id}/dag_runs"
@@ -72,6 +85,7 @@ class Client(api_client.Client):
             "conf": conf,
             "execution_date": execution_date,
             "replace_microseconds": replace_microseconds,
+            "triggered_by": triggered_by,
         }
         return self._request(url, method="POST", json=data)["message"]
 

--- a/airflow/api/client/local_client.py
+++ b/airflow/api/client/local_client.py
@@ -19,18 +19,29 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from airflow.api.client import api_client
 from airflow.api.common import delete_dag, trigger_dag
 from airflow.api.common.experimental.get_lineage import get_lineage as get_lineage_api
 from airflow.exceptions import AirflowBadRequest, PoolNotFound
 from airflow.models.pool import Pool
 
+if TYPE_CHECKING:
+    from airflow.utils.types import DagRunTriggeredByType
+
 
 class Client(api_client.Client):
     """Local API client implementation."""
 
     def trigger_dag(
-        self, dag_id, run_id=None, conf=None, execution_date=None, replace_microseconds=True
+        self,
+        dag_id,
+        run_id=None,
+        conf=None,
+        execution_date=None,
+        replace_microseconds=True,
+        triggered_by: DagRunTriggeredByType | None = None,
     ) -> dict | None:
         dag_run = trigger_dag.trigger_dag(
             dag_id=dag_id,
@@ -38,6 +49,7 @@ class Client(api_client.Client):
             conf=conf,
             execution_date=execution_date,
             replace_microseconds=replace_microseconds,
+            triggered_by=triggered_by,
         )
         if dag_run:
             return {
@@ -53,6 +65,7 @@ class Client(api_client.Client):
                 "run_type": dag_run.run_type,
                 "start_date": dag_run.start_date,
                 "state": dag_run.state,
+                "triggered_by": dag_run.triggered_by,
             }
         return dag_run
 

--- a/airflow/api/common/mark_tasks.py
+++ b/airflow/api/common/mark_tasks.py
@@ -31,7 +31,7 @@ from airflow.utils import timezone
 from airflow.utils.helpers import exactly_one
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -76,6 +76,7 @@ def _create_dagruns(
                 external_trigger=False,
                 state=state,
                 run_type=run_type,
+                triggered_by=DagRunTriggeredByType.SCHEDULER,
             )
     return dag_runs.values()
 

--- a/airflow/api/common/trigger_dag.py
+++ b/airflow/api/common/trigger_dag.py
@@ -26,7 +26,7 @@ from airflow.exceptions import DagNotFound, DagRunAlreadyExists
 from airflow.models import DagBag, DagModel, DagRun
 from airflow.utils import timezone
 from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -39,6 +39,7 @@ def _trigger_dag(
     conf: dict | str | None = None,
     execution_date: datetime | None = None,
     replace_microseconds: bool = True,
+    triggered_by: DagRunTriggeredByType | None = None,
 ) -> list[DagRun | None]:
     """Triggers DAG run.
 
@@ -48,6 +49,7 @@ def _trigger_dag(
     :param conf: configuration
     :param execution_date: date of execution
     :param replace_microseconds: whether microseconds should be zeroed
+    :param triggered_by: the entity which triggers the dag_run
     :return: list of triggered dags
     """
     dag = dag_bag.get_dag(dag_id)  # prefetch dag if it is stored serialized
@@ -96,6 +98,7 @@ def _trigger_dag(
             external_trigger=True,
             dag_hash=dag_bag.dags_hash.get(dag_id),
             data_interval=data_interval,
+            triggered_by=triggered_by,
         )
         dag_runs.append(dag_run)
 
@@ -108,6 +111,7 @@ def trigger_dag(
     conf: dict | str | None = None,
     execution_date: datetime | None = None,
     replace_microseconds: bool = True,
+    triggered_by: DagRunTriggeredByType | None = None,
 ) -> DagRun | None:
     """Triggers execution of DAG specified by dag_id.
 
@@ -116,6 +120,7 @@ def trigger_dag(
     :param conf: configuration
     :param execution_date: date of execution
     :param replace_microseconds: whether microseconds should be zeroed
+    :param triggered_by: the entity which triggers the dag_run
     :return: first dag run triggered - even if more than one Dag Runs were triggered or None
     """
     dag_model = DagModel.get_current(dag_id)
@@ -130,6 +135,7 @@ def trigger_dag(
         conf=conf,
         execution_date=execution_date,
         replace_microseconds=replace_microseconds,
+        triggered_by=triggered_by,
     )
 
     return triggers[0] if triggers else None

--- a/airflow/api_connexion/endpoints/dag_run_endpoint.py
+++ b/airflow/api_connexion/endpoints/dag_run_endpoint.py
@@ -65,7 +65,7 @@ from airflow.utils.airflow_flask_app import get_airflow_app
 from airflow.utils.db import get_query_count
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 from airflow.www.decorators import action_logging
 from airflow.www.extensions.init_auth_manager import get_auth_manager
 
@@ -350,6 +350,7 @@ def post_dag_run(*, dag_id: str, session: Session = NEW_SESSION) -> APIResponse:
                 external_trigger=True,
                 dag_hash=get_airflow_app().dag_bag.dags_hash.get(dag_id),
                 session=session,
+                triggered_by=DagRunTriggeredByType.REST_API,
             )
             dag_run_note = post_body.get("note")
             if dag_run_note:

--- a/airflow/api_connexion/schemas/dag_run_schema.py
+++ b/airflow/api_connexion/schemas/dag_run_schema.py
@@ -74,6 +74,7 @@ class DAGRunSchema(SQLAlchemySchema):
     last_scheduling_decision = auto_field(dump_only=True)
     run_type = auto_field(dump_only=True)
     note = auto_field(dump_only=False)
+    triggered_by = auto_field(dump_only=True)
 
     @pre_load
     def autogenerate(self, data, **kwargs):

--- a/airflow/cli/commands/dag_command.py
+++ b/airflow/cli/commands/dag_command.py
@@ -49,6 +49,7 @@ from airflow.utils.helpers import ask_yesno
 from airflow.utils.providers_configuration_loader import providers_configuration_loaded
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState
+from airflow.utils.types import DagRunTriggeredByType
 
 if TYPE_CHECKING:
     from graphviz.dot import Dot
@@ -86,6 +87,7 @@ def _run_dag_backfill(dags: list[DAG], args) -> None:
                     dag.dag_id,
                     execution_date=dagrun_info.logical_date,
                     data_interval=dagrun_info.data_interval,
+                    triggered_by=DagRunTriggeredByType.CLI,
                 )
 
                 for task in dag.tasks:
@@ -176,6 +178,7 @@ def dag_trigger(args) -> None:
             conf=args.conf,
             execution_date=args.exec_date,
             replace_microseconds=args.replace_microseconds,
+            triggered_by=DagRunTriggeredByType.CLI,
         )
         AirflowConsole().print_as(
             data=[message] if message is not None else [],

--- a/airflow/cli/commands/task_command.py
+++ b/airflow/cli/commands/task_command.py
@@ -71,6 +71,7 @@ from airflow.utils.providers_configuration_loader import providers_configuration
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState
 from airflow.utils.task_instance_session import set_current_task_instance_session
+from airflow.utils.types import DagRunTriggeredByType
 
 if TYPE_CHECKING:
     from sqlalchemy.orm.session import Session
@@ -142,6 +143,7 @@ def _get_dag_run(
             run_id=exec_date_or_run_id,
             execution_date=dag_run_execution_date,
             data_interval=dag.timetable.infer_manual_data_interval(run_after=dag_run_execution_date),
+            triggered_by=DagRunTriggeredByType.CLI,
         )
         return dag_run, True
     elif create_if_necessary == "db":
@@ -151,6 +153,7 @@ def _get_dag_run(
             run_id=_generate_temporary_run_id(),
             data_interval=dag.timetable.infer_manual_data_interval(run_after=dag_run_execution_date),
             session=session,
+            triggered_by=DagRunTriggeredByType.CLI,
         )
         return dag_run, True
     raise ValueError(f"unknown create_if_necessary value: {create_if_necessary!r}")

--- a/airflow/jobs/backfill_job_runner.py
+++ b/airflow/jobs/backfill_job_runner.py
@@ -50,7 +50,7 @@ from airflow.utils.configuration import conf as airflow_conf, tmp_configuration_
 from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.state import DagRunState, State, TaskInstanceState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
     import datetime
@@ -381,6 +381,7 @@ class BackfillJobRunner(BaseJobRunner, LoggingMixin):
             conf=self.conf,
             run_type=DagRunType.BACKFILL_JOB,
             creating_job_id=self.job.id,
+            triggered_by=DagRunTriggeredByType.SCHEDULER,
         )
 
         # set required transient field

--- a/airflow/jobs/scheduler_job_runner.py
+++ b/airflow/jobs/scheduler_job_runner.py
@@ -72,7 +72,7 @@ from airflow.utils.sqlalchemy import (
     with_row_locks,
 )
 from airflow.utils.state import DagRunState, JobState, State, TaskInstanceState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
     import logging
@@ -1179,6 +1179,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                         session=session,
                         dag_hash=dag_hash,
                         creating_job_id=self.job.id,
+                        triggered_by=DagRunTriggeredByType.SCHEDULER,
                     )
                     active_runs_of_dags[dag.dag_id] += 1
                 # Exceptions like ValueError, ParamValidationError, etc. are raised by
@@ -1292,6 +1293,7 @@ class SchedulerJobRunner(BaseJobRunner, LoggingMixin):
                     session=session,
                     dag_hash=dag_hash,
                     creating_job_id=self.job.id,
+                    triggered_by=DagRunTriggeredByType.DATASET,
                 )
                 Stats.incr("dataset.triggered_dagruns")
                 dag_run.consumed_dataset_events.extend(dataset_events)

--- a/airflow/models/baseoperator.py
+++ b/airflow/models/baseoperator.py
@@ -100,7 +100,7 @@ from airflow.utils.operator_resources import Resources
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.setup_teardown import SetupTeardownContext
 from airflow.utils.trigger_rule import TriggerRule
-from airflow.utils.types import NOTSET
+from airflow.utils.types import NOTSET, DagRunTriggeredByType
 from airflow.utils.xcom import XCOM_RETURN_KEY
 
 if TYPE_CHECKING:
@@ -1455,6 +1455,7 @@ class BaseOperator(AbstractOperator, metaclass=BaseOperatorMeta):
                     run_type=DagRunType.MANUAL,
                     execution_date=info.logical_date,
                     data_interval=info.data_interval,
+                    triggered_by=DagRunTriggeredByType.TEST,
                 )
                 ti = TaskInstance(self, run_id=dr.run_id)
                 ti.dag_run = dr

--- a/airflow/models/dagrun.py
+++ b/airflow/models/dagrun.py
@@ -68,7 +68,7 @@ from airflow.utils.log.logging_mixin import LoggingMixin
 from airflow.utils.session import NEW_SESSION, provide_session
 from airflow.utils.sqlalchemy import UtcDateTime, nulls_first, tuple_in_condition, with_row_locks
 from airflow.utils.state import DagRunState, State, TaskInstanceState
-from airflow.utils.types import NOTSET, DagRunType
+from airflow.utils.types import NOTSET, DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -128,6 +128,7 @@ class DagRun(Base, LoggingMixin):
     creating_job_id = Column(Integer)
     external_trigger = Column(Boolean, default=True)
     run_type = Column(String(50), nullable=False)
+    triggered_by = Column(String(50))  # who triggered the DAG Run
     conf = Column(PickleType)
     # These two must be either both NULL or both datetime.
     data_interval_start = Column(UtcDateTime)
@@ -177,6 +178,7 @@ class DagRun(Base, LoggingMixin):
             postgresql_where=text("state='queued'"),
             sqlite_where=text("state='queued'"),
         ),
+        Index("idx_dag_run_triggered_by", triggered_by),
     )
 
     task_instances = relationship(
@@ -216,6 +218,7 @@ class DagRun(Base, LoggingMixin):
         dag_hash: str | None = None,
         creating_job_id: int | None = None,
         data_interval: tuple[datetime, datetime] | None = None,
+        triggered_by: DagRunTriggeredByType | None = None,
     ):
         if data_interval is None:
             # Legacy: Only happen for runs created prior to Airflow 2.2.
@@ -239,6 +242,7 @@ class DagRun(Base, LoggingMixin):
         self.dag_hash = dag_hash
         self.creating_job_id = creating_job_id
         self.clear_number = 0
+        self.triggered_by = triggered_by
         super().__init__()
 
     def __repr__(self):

--- a/airflow/operators/subdag.py
+++ b/airflow/operators/subdag.py
@@ -38,7 +38,7 @@ from airflow.models.taskinstance import TaskInstance
 from airflow.sensors.base import BaseSensorOperator
 from airflow.utils.session import NEW_SESSION, create_session, provide_session
 from airflow.utils.state import DagRunState, TaskInstanceState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -176,6 +176,7 @@ class SubDagOperator(BaseSensorOperator):
                 conf=self.conf,
                 external_trigger=True,
                 data_interval=data_interval,
+                triggered_by=DagRunTriggeredByType.OPERATOR,
             )
             self.log.info("Created DagRun: %s", dag_run.run_id)
         else:

--- a/airflow/operators/trigger_dagrun.py
+++ b/airflow/operators/trigger_dagrun.py
@@ -39,7 +39,7 @@ from airflow.utils import timezone
 from airflow.utils.helpers import build_airflow_url_with_query
 from airflow.utils.session import provide_session
 from airflow.utils.state import DagRunState
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 
 XCOM_EXECUTION_DATE_ISO = "trigger_execution_date_iso"
 XCOM_RUN_ID = "trigger_run_id"
@@ -168,6 +168,7 @@ class TriggerDagRunOperator(BaseOperator):
                 conf=self.conf,
                 execution_date=parsed_execution_date,
                 replace_microseconds=False,
+                triggered_by=DagRunTriggeredByType.OPERATOR,
             )
 
         except DagRunAlreadyExists as e:

--- a/airflow/serialization/pydantic/dag_run.py
+++ b/airflow/serialization/pydantic/dag_run.py
@@ -23,6 +23,7 @@ from airflow.serialization.pydantic.dag import PydanticDag
 from airflow.serialization.pydantic.dataset import DatasetEventPydantic
 from airflow.utils.pydantic import BaseModel as BaseModelPydantic, ConfigDict, is_pydantic_2_installed
 from airflow.utils.session import NEW_SESSION, provide_session
+from airflow.utils.types import DagRunTriggeredByType
 
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
@@ -55,6 +56,7 @@ class DagRunPydantic(BaseModelPydantic):
     dag: Optional[PydanticDag]
     consumed_dataset_events: List[DatasetEventPydantic]  # noqa: UP006
     log_template_id: Optional[int]
+    triggered_by: Optional[DagRunTriggeredByType]
 
     model_config = ConfigDict(from_attributes=True, arbitrary_types_allowed=True)
 

--- a/airflow/utils/types.py
+++ b/airflow/utils/types.py
@@ -72,3 +72,18 @@ class EdgeInfoType(TypedDict):
     """Extra metadata that the DAG can store about an edge, usually generated from an EdgeModifier."""
 
     label: str | None
+
+
+class DagRunTriggeredByType(str, enum.Enum):
+    """Class with TriggeredBy types for DagRun."""
+
+    CLI = "cli"  # for the trigger subcommand for dag command in cli: airflow dags trigger
+    OPERATOR = "operator"  # for the TriggerDagRunOperator
+    REST_API = "rest_api"  # for triggering the DAG via RESTful API
+    UI = "ui"  # for clicking the `Trigger DAG` button
+    TEST = "test"  # for dag.test()
+    SCHEDULER = "scheduler"  # for scheduler
+    DATASET = "dataset"  # for dataset_triggered run type
+
+    def __str__(self):
+        return self.value

--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -35,6 +35,7 @@ from airflow.exceptions import AirflowException
 from airflow.utils import timezone
 from airflow.utils.docs import get_docs_url
 from airflow.utils.strings import to_boolean
+from airflow.utils.types import DagRunTriggeredByType
 from airflow.version import version
 
 if TYPE_CHECKING:
@@ -124,7 +125,14 @@ def trigger_dag(dag_id):
         replace_microseconds = to_boolean(data["replace_microseconds"])
 
     try:
-        dr = trigger.trigger_dag(dag_id, run_id, conf, execution_date, replace_microseconds)
+        dr = trigger.trigger_dag(
+            dag_id,
+            run_id,
+            conf,
+            execution_date,
+            replace_microseconds,
+            triggered_by=DagRunTriggeredByType.REST_API,
+        )
     except AirflowException as err:
         log.error(err)
         response = jsonify(error=f"{err}")

--- a/airflow/www/views.py
+++ b/airflow/www/views.py
@@ -130,7 +130,7 @@ from airflow.utils.state import DagRunState, State, TaskInstanceState
 from airflow.utils.strings import to_boolean
 from airflow.utils.task_group import TaskGroup, task_group_to_dict
 from airflow.utils.timezone import td_format, utcnow
-from airflow.utils.types import NOTSET
+from airflow.utils.types import NOTSET, DagRunTriggeredByType
 from airflow.version import version
 from airflow.www import auth, utils as wwwutils
 from airflow.www.decorators import action_logging, gzipped
@@ -2153,6 +2153,7 @@ class Airflow(AirflowBaseView):
                 external_trigger=True,
                 dag_hash=get_airflow_app().dag_bag.dags_hash.get(dag_id),
                 run_id=run_id,
+                triggered_by=DagRunTriggeredByType.UI,
             )
         except (ValueError, ParamValidationError) as ve:
             flash(f"{ve}", "error")

--- a/dev/perf/scheduler_dag_execution_timing.py
+++ b/dev/perf/scheduler_dag_execution_timing.py
@@ -29,6 +29,7 @@ from operator import attrgetter
 import rich_click as click
 
 from airflow.jobs.job import run_job
+from airflow.utils.types import DagRunTriggeredByType
 
 MAX_DAG_RUNS_ALLOWED = 1
 
@@ -178,6 +179,7 @@ def create_dag_runs(dag, num_runs, session):
             state=DagRunState.RUNNING,
             external_trigger=False,
             session=session,
+            triggered_by=DagRunTriggeredByType.TEST,
         )
         last_dagrun_data_interval = next_info.data_interval
 

--- a/tests/api_connexion/endpoints/test_dag_run_endpoint.py
+++ b/tests/api_connexion/endpoints/test_dag_run_endpoint.py
@@ -33,7 +33,7 @@ from airflow.security import permissions
 from airflow.utils import timezone
 from airflow.utils.session import create_session, provide_session
 from airflow.utils.state import DagRunState, State
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 from tests.test_utils.api_connexion_utils import assert_401, create_user, delete_roles, delete_user
 from tests.test_utils.config import conf_vars
 from tests.test_utils.db import clear_db_dags, clear_db_runs, clear_db_serialized_dags
@@ -146,6 +146,7 @@ class TestDagRunEndpoint:
                 start_date=timezone.parse(self.default_time),
                 external_trigger=True,
                 state=state,
+                triggered_by=DagRunTriggeredByType.TEST,
             )
             dagrun_model.updated_at = timezone.parse(self.default_time)
             dag_runs.append(dagrun_model)
@@ -225,6 +226,7 @@ class TestGetDagRun(TestDagRunEndpoint):
             start_date=timezone.parse(self.default_time),
             external_trigger=True,
             state="running",
+            triggered_by=DagRunTriggeredByType.TEST,
         )
         session.add(dagrun_model)
         session.commit()
@@ -249,6 +251,7 @@ class TestGetDagRun(TestDagRunEndpoint):
             "last_scheduling_decision": None,
             "run_type": "manual",
             "note": None,
+            "triggered_by": "test",
         }
 
     def test_should_respond_404(self):
@@ -360,6 +363,7 @@ class TestGetDagRuns(TestDagRunEndpoint):
                     "last_scheduling_decision": None,
                     "run_type": "manual",
                     "note": None,
+                    "triggered_by": "test",
                 },
                 {
                     "dag_id": "TEST_DAG_ID",
@@ -376,6 +380,7 @@ class TestGetDagRuns(TestDagRunEndpoint):
                     "last_scheduling_decision": None,
                     "run_type": "manual",
                     "note": None,
+                    "triggered_by": "test",
                 },
             ],
             "total_entries": 2,
@@ -432,6 +437,7 @@ class TestGetDagRuns(TestDagRunEndpoint):
                     "last_scheduling_decision": None,
                     "run_type": "manual",
                     "note": None,
+                    "triggered_by": "test",
                 },
                 {
                     "dag_id": "TEST_DAG_ID",
@@ -448,6 +454,7 @@ class TestGetDagRuns(TestDagRunEndpoint):
                     "last_scheduling_decision": None,
                     "run_type": "manual",
                     "note": None,
+                    "triggered_by": "test",
                 },
             ],
             "total_entries": 2,
@@ -752,6 +759,7 @@ class TestGetDagRunBatch(TestDagRunEndpoint):
                     "last_scheduling_decision": None,
                     "run_type": "manual",
                     "note": None,
+                    "triggered_by": "test",
                 },
                 {
                     "dag_id": "TEST_DAG_ID",
@@ -768,6 +776,7 @@ class TestGetDagRunBatch(TestDagRunEndpoint):
                     "last_scheduling_decision": None,
                     "run_type": "manual",
                     "note": None,
+                    "triggered_by": "test",
                 },
             ],
             "total_entries": 2,
@@ -826,6 +835,7 @@ class TestGetDagRunBatch(TestDagRunEndpoint):
                     "last_scheduling_decision": None,
                     "run_type": "manual",
                     "note": None,
+                    "triggered_by": "test",
                 },
                 {
                     "dag_id": "TEST_DAG_ID",
@@ -842,6 +852,7 @@ class TestGetDagRunBatch(TestDagRunEndpoint):
                     "last_scheduling_decision": None,
                     "run_type": "manual",
                     "note": None,
+                    "triggered_by": "test",
                 },
             ],
             "total_entries": 2,
@@ -883,6 +894,7 @@ class TestGetDagRunBatch(TestDagRunEndpoint):
                     "last_scheduling_decision": None,
                     "run_type": "manual",
                     "note": None,
+                    "triggered_by": "test",
                 },
                 {
                     "dag_id": "TEST_DAG_ID",
@@ -899,6 +911,7 @@ class TestGetDagRunBatch(TestDagRunEndpoint):
                     "last_scheduling_decision": None,
                     "run_type": "manual",
                     "note": None,
+                    "triggered_by": "test",
                 },
             ],
             "total_entries": 2,
@@ -1243,6 +1256,7 @@ class TestPostDagRun(TestDagRunEndpoint):
             "last_scheduling_decision": None,
             "run_type": "manual",
             "note": note,
+            "triggered_by": "rest_api",
         }
         _check_last_log(session, dag_id="TEST_DAG_ID", event="api.post_dag_run", execution_date=None)
 
@@ -1341,6 +1355,7 @@ class TestPostDagRun(TestDagRunEndpoint):
             "last_scheduling_decision": None,
             "run_type": "manual",
             "note": None,
+            "triggered_by": "rest_api",
         }
 
     def test_should_response_400_for_conflicting_execution_date_logical_date(self):
@@ -1610,6 +1625,7 @@ class TestPatchDagRunState(TestDagRunEndpoint):
             "last_scheduling_decision": None,
             "run_type": run_type,
             "note": None,
+            "triggered_by": "test",
         }
 
     def test_schema_validation_error_raises(self, dag_maker, session):
@@ -1727,6 +1743,7 @@ class TestClearDagRun(TestDagRunEndpoint):
             "last_scheduling_decision": None,
             "run_type": dr.run_type,
             "note": None,
+            "triggered_by": "test",
         }
 
         ti.refresh_from_db()
@@ -1948,6 +1965,7 @@ class TestSetDagRunNote(TestDagRunEndpoint):
             "last_scheduling_decision": None,
             "run_type": dr.run_type,
             "note": new_note_value,
+            "triggered_by": "test",
         }
         assert dr.dag_run_note.user_id is not None
         # Update the note again
@@ -1974,6 +1992,7 @@ class TestSetDagRunNote(TestDagRunEndpoint):
             "last_scheduling_decision": None,
             "run_type": dr.run_type,
             "note": new_note_value,
+            "triggered_by": "test",
         }
         assert dr.dag_run_note.user_id is not None
         _check_last_log(

--- a/tests/api_connexion/schemas/test_dag_run_schema.py
+++ b/tests/api_connexion/schemas/test_dag_run_schema.py
@@ -28,7 +28,7 @@ from airflow.api_connexion.schemas.dag_run_schema import (
 from airflow.models import DagRun
 from airflow.utils import timezone
 from airflow.utils.session import provide_session
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 from tests.test_utils.db import clear_db_runs
 
 DEFAULT_TIME = "2020-06-09T13:59:56.336000+00:00"
@@ -59,6 +59,7 @@ class TestDAGRunSchema(TestDAGRunBase):
             execution_date=timezone.parse(self.default_time),
             start_date=timezone.parse(self.default_time),
             conf='{"start": "stop"}',
+            triggered_by=DagRunTriggeredByType.TEST,
         )
         session.add(dagrun_model)
         session.commit()
@@ -80,6 +81,7 @@ class TestDAGRunSchema(TestDAGRunBase):
             "last_scheduling_decision": None,
             "run_type": "manual",
             "note": None,
+            "triggered_by": "test",
         }
 
     @pytest.mark.parametrize(
@@ -143,6 +145,7 @@ class TestDagRunCollection(TestDAGRunBase):
             run_type=DagRunType.MANUAL.value,
             start_date=timezone.parse(self.default_time),
             conf='{"start": "stop"}',
+            triggered_by=DagRunTriggeredByType.REST_API,
         )
         dagrun_model_2 = DagRun(
             dag_id="my-dag-run",
@@ -151,6 +154,7 @@ class TestDagRunCollection(TestDAGRunBase):
             execution_date=timezone.parse(self.second_time),
             start_date=timezone.parse(self.default_time),
             run_type=DagRunType.MANUAL.value,
+            triggered_by=DagRunTriggeredByType.UI,
         )
         dagruns = [dagrun_model_1, dagrun_model_2]
         session.add_all(dagruns)
@@ -174,6 +178,7 @@ class TestDagRunCollection(TestDAGRunBase):
                     "last_scheduling_decision": None,
                     "run_type": "manual",
                     "note": None,
+                    "triggered_by": "rest_api",
                 },
                 {
                     "dag_id": "my-dag-run",
@@ -190,6 +195,7 @@ class TestDagRunCollection(TestDAGRunBase):
                     "last_scheduling_decision": None,
                     "run_type": "manual",
                     "note": None,
+                    "triggered_by": "ui",
                 },
             ],
             "total_entries": 2,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -845,6 +845,8 @@ def dag_maker(request):
                 else:
                     data_interval = dag.infer_automated_data_interval(logical_date)
                 kwargs["data_interval"] = data_interval
+            if "triggered_by" not in kwargs:
+                kwargs["triggered_by"] = "test"
 
             self.dag_run = dag.create_dagrun(**kwargs)
             for ti in self.dag_run.task_instances:

--- a/tests/operators/test_subdag_operator.py
+++ b/tests/operators/test_subdag_operator.py
@@ -32,7 +32,7 @@ from airflow.operators.subdag import SkippedStatePropagationOptions, SubDagOpera
 from airflow.utils.session import create_session
 from airflow.utils.state import State
 from airflow.utils.timezone import datetime
-from airflow.utils.types import DagRunType
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 from tests.test_utils.db import clear_db_runs
 
 pytestmark = pytest.mark.db_test
@@ -168,6 +168,7 @@ class TestSubDagOperator:
             conf=None,
             state=State.RUNNING,
             external_trigger=True,
+            triggered_by=DagRunTriggeredByType.OPERATOR,
         )
 
         assert 3 == subdag_task._get_dagrun.call_count
@@ -205,6 +206,7 @@ class TestSubDagOperator:
             conf=conf,
             state=State.RUNNING,
             external_trigger=True,
+            triggered_by=DagRunTriggeredByType.OPERATOR,
         )
 
         assert 3 == subdag_task._get_dagrun.call_count


### PR DESCRIPTION
Add `triggered_by` field to DAG Run model to distinguish the source of a trigger.
This is for the discussion in https://github.com/apache/airflow/pull/37087. 

Currently this has only the backend stuff. No changes done on frontend. 

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
