### PR TITLE
Fix system test example_cloud_memorystore_memcached

### DIFF
--- a/tests/system/providers/google/cloud/cloud_memorystore/example_cloud_memorystore_memcached.py
+++ b/tests/system/providers/google/cloud/cloud_memorystore/example_cloud_memorystore_memcached.py
@@ -61,7 +61,7 @@ MEMCACHED_INSTANCE = {
 }
 # [END howto_operator_memcached_instance]
 
-IP_RANGE_NAME = f"ip-range-{DAG_ID}-{ENV_ID}".replace("_", "-")
+IP_RANGE_NAME = f"ip-range-{DAG_ID}".replace("_", "-")
 NETWORK = "default"
 CREATE_PRIVATE_CONNECTION_CMD = f"""
 if [ $AIRFLOW__API__GOOGLE_KEY_PATH ]; then \


### PR DESCRIPTION
Fixed the system test `example_cloud_memorystore_memcached`.
IP range now will be created only once for the DAG, not for each run.

Justification:
The Metastore service requires a private connection configured with an IP range. Thus an additional preparation step was added to the DAG - create an IP range and associate it with a private connection. The only mistake was made here is that the IP range was created for each run, and never deleted it afterwards.
As a solution, we could delete this IP range and the private connection. But I think it would be cheaper for us to re-use the IP range and the private connection created earlier, because:
1. in this case we don't have to implement deletion via BashOperator
2. less code => simpler DAG + less potential bugs => easier to maintain.

That's why I simply renamed the IP-range so it now depends only on DAG id, which remains the same for each run.