### PR TITLE
Deprecate AutoMLTablesListTableSpecsOperator and AutoMLTablesListColumnSpecsOperator

### DIFF
--- a/airflow/providers/google/cloud/operators/automl.py
+++ b/airflow/providers/google/cloud/operators/automl.py
@@ -676,9 +676,24 @@ class AutoMLImportDataOperator(GoogleCloudBaseOperator):
             )
 
 
+@deprecated(
+    reason=(
+        "Class `AutoMLTablesListColumnSpecsOperator` has been deprecated and will be removed after 31.12.2024. "
+        "AutoML platform no longer supports tabular datasets after its integration with Cloud Translation and Vertex AI. "
+        "Please refer to https://cloud.google.com/vertex-ai/docs/start/migrating-to-vertex-ai and "
+        "https://cloud.google.com/translate/docs/advanced/automl-upgrade for more info about available alternatives."
+    ),
+    category=AirflowProviderDeprecationWarning,
+    action="error",
+)
 class AutoMLTablesListColumnSpecsOperator(GoogleCloudBaseOperator):
     """
     Lists column specs in a table.
+
+    Class `AutoMLTablesListColumnSpecsOperator` has been deprecated and will be removed after 31.12.2024.
+    AutoML platform no longer supports tabular datasets after its integration with Cloud Translation and Vertex AI.
+    Please refer to https://cloud.google.com/vertex-ai/docs/start/migrating-to-vertex-ai and
+    "https://cloud.google.com/translate/docs/advanced/automl-upgrade for more info about available alternatives.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
@@ -1182,9 +1197,24 @@ class AutoMLDeployModelOperator(GoogleCloudBaseOperator):
         self.log.info("Model was deployed successfully.")
 
 
+@deprecated(
+    reason=(
+        "Class `AutoMLTablesListTableSpecsOperator` has been deprecated and will be removed after 31.12.2024. "
+        "AutoML platform no longer supports tabular datasets after its integration with Cloud Translation and Vertex AI. "
+        "Please refer to https://cloud.google.com/vertex-ai/docs/start/migrating-to-vertex-ai and "
+        "https://cloud.google.com/translate/docs/advanced/automl-upgrade for more info about available alternatives."
+    ),
+    category=AirflowProviderDeprecationWarning,
+    action="error",
+)
 class AutoMLTablesListTableSpecsOperator(GoogleCloudBaseOperator):
     """
     Lists table specs in a dataset.
+
+    Class `AutoMLTablesListTableSpecsOperator` has been deprecated and will be removed after 31.12.2024.
+    AutoML platform no longer supports tabular datasets after its integration with Cloud Translation and Vertex AI.
+    Please refer to https://cloud.google.com/vertex-ai/docs/start/migrating-to-vertex-ai and
+    "https://cloud.google.com/translate/docs/advanced/automl-upgrade for more info about available alternatives.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:

--- a/scripts/in_container/run_provider_yaml_files_check.py
+++ b/scripts/in_container/run_provider_yaml_files_check.py
@@ -57,6 +57,8 @@ DEPRECATED_MODULES = [
 
 KNOWN_DEPRECATED_CLASSES = [
     "airflow.providers.google.cloud.links.dataproc.DataprocLink",
+    "airflow.providers.google.cloud.operators.automl.AutoMLTablesListColumnSpecsOperator",
+    "airflow.providers.google.cloud.operators.automl.AutoMLTablesListTableSpecsOperator",
     "airflow.providers.google.cloud.operators.automl.AutoMLTablesUpdateDatasetOperator",
     "airflow.providers.google.cloud.operators.automl.AutoMLDeployModelOperator",
 ]

--- a/tests/always/test_project_structure.py
+++ b/tests/always/test_project_structure.py
@@ -363,6 +363,8 @@ class TestGoogleProviderProjectStructure(ExampleCoverageTest, AssetsCoverageTest
         ".CloudDataTransferServiceS3ToGCSOperator",
         "airflow.providers.google.cloud.operators.cloud_storage_transfer_service"
         ".CloudDataTransferServiceGCSToGCSOperator",
+        "airflow.providers.google.cloud.operators.automl.AutoMLTablesListColumnSpecsOperator",
+        "airflow.providers.google.cloud.operators.automl.AutoMLTablesListTableSpecsOperator",
         "airflow.providers.google.cloud.operators.automl.AutoMLTablesUpdateDatasetOperator",
         "airflow.providers.google.cloud.operators.automl.AutoMLDeployModelOperator",
         "airflow.providers.google.cloud.operators.dataproc.DataprocSubmitHadoopJobOperator",

--- a/tests/providers/google/cloud/operators/test_automl.py
+++ b/tests/providers/google/cloud/operators/test_automl.py
@@ -379,63 +379,51 @@ class TestAutoMLCreateImportOperator:
         assert task.impersonation_chain == "impersonation-chain"
 
 
-class TestAutoMLListColumnsSpecsOperator:
+class TestAutoMLTablesListColumnsSpecsOperator:
+    expected_deprecation_warning = (
+        "Class `AutoMLTablesListColumnSpecsOperator` has been deprecated and will be removed after 31.12.2024. "
+        "AutoML platform no longer supports tabular datasets after its integration with Cloud Translation and Vertex AI. "
+        "Please refer to https://cloud.google.com/vertex-ai/docs/start/migrating-to-vertex-ai and "
+        "https://cloud.google.com/translate/docs/advanced/automl-upgrade for more info about available alternatives."
+    )
+
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         table_spec = "table_spec_id"
         filter_ = "filter"
         page_size = 42
 
-        op = AutoMLTablesListColumnSpecsOperator(
-            dataset_id=DATASET_ID,
-            table_spec_id=table_spec,
-            location=GCP_LOCATION,
-            project_id=GCP_PROJECT_ID,
-            field_mask=MASK,
-            filter_=filter_,
-            page_size=page_size,
-            task_id=TASK_ID,
-        )
-        op.execute(context=mock.MagicMock())
-        mock_hook.return_value.list_column_specs.assert_called_once_with(
-            dataset_id=DATASET_ID,
-            field_mask=MASK,
-            filter_=filter_,
-            location=GCP_LOCATION,
-            metadata=(),
-            page_size=page_size,
-            project_id=GCP_PROJECT_ID,
-            retry=DEFAULT,
-            table_spec_id=table_spec,
-            timeout=None,
-        )
+        with pytest.raises(AirflowProviderDeprecationWarning, match=self.expected_deprecation_warning):
+            _ = AutoMLTablesListColumnSpecsOperator(
+                dataset_id=DATASET_ID,
+                table_spec_id=table_spec,
+                location=GCP_LOCATION,
+                project_id=GCP_PROJECT_ID,
+                field_mask=MASK,
+                filter_=filter_,
+                page_size=page_size,
+                task_id=TASK_ID,
+            )
+        mock_hook.assert_not_called()
 
     @pytest.mark.db_test
     def test_templating(self, create_task_instance_of_operator):
-        ti = create_task_instance_of_operator(
-            AutoMLTablesListColumnSpecsOperator,
-            # Templated fields
-            dataset_id="{{ 'dataset-id' }}",
-            table_spec_id="{{ 'table-spec-id' }}",
-            field_mask="{{ 'field-mask' }}",
-            filter_="{{ 'filter-' }}",
-            location="{{ 'location' }}",
-            project_id="{{ 'project-id' }}",
-            impersonation_chain="{{ 'impersonation-chain' }}",
-            # Other parameters
-            dag_id="test_template_body_templating_dag",
-            task_id="test_template_body_templating_task",
-            execution_date=timezone.datetime(2024, 2, 1, tzinfo=timezone.utc),
-        )
-        ti.render_templates()
-        task: AutoMLTablesListColumnSpecsOperator = ti.task
-        assert task.dataset_id == "dataset-id"
-        assert task.table_spec_id == "table-spec-id"
-        assert task.field_mask == "field-mask"
-        assert task.filter_ == "filter-"
-        assert task.location == "location"
-        assert task.project_id == "project-id"
-        assert task.impersonation_chain == "impersonation-chain"
+        with pytest.raises(AirflowProviderDeprecationWarning, match=self.expected_deprecation_warning):
+            _ = create_task_instance_of_operator(
+                AutoMLTablesListColumnSpecsOperator,
+                # Templated fields
+                dataset_id="{{ 'dataset-id' }}",
+                table_spec_id="{{ 'table-spec-id' }}",
+                field_mask="{{ 'field-mask' }}",
+                filter_="{{ 'filter-' }}",
+                location="{{ 'location' }}",
+                project_id="{{ 'project-id' }}",
+                impersonation_chain="{{ 'impersonation-chain' }}",
+                # Other parameters
+                dag_id="test_template_body_templating_dag",
+                task_id="test_template_body_templating_task",
+                execution_date=timezone.datetime(2024, 2, 1, tzinfo=timezone.utc),
+            )
 
 
 class TestAutoMLUpdateDatasetOperator:
@@ -737,53 +725,45 @@ class TestAutoMLDatasetImportOperator:
 
 
 class TestAutoMLTablesListTableSpecsOperator:
+    expected_deprecation_warning = (
+        "Class `AutoMLTablesListTableSpecsOperator` has been deprecated and will be removed after 31.12.2024. "
+        "AutoML platform no longer supports tabular datasets after its integration with Cloud Translation and Vertex AI. "
+        "Please refer to https://cloud.google.com/vertex-ai/docs/start/migrating-to-vertex-ai and "
+        "https://cloud.google.com/translate/docs/advanced/automl-upgrade for more info about available alternatives."
+    )
+
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook):
         filter_ = "filter"
         page_size = 42
 
-        op = AutoMLTablesListTableSpecsOperator(
-            dataset_id=DATASET_ID,
-            location=GCP_LOCATION,
-            project_id=GCP_PROJECT_ID,
-            filter_=filter_,
-            page_size=page_size,
-            task_id=TASK_ID,
-        )
-        op.execute(context=mock.MagicMock())
-        mock_hook.return_value.list_table_specs.assert_called_once_with(
-            dataset_id=DATASET_ID,
-            filter_=filter_,
-            location=GCP_LOCATION,
-            metadata=(),
-            page_size=page_size,
-            project_id=GCP_PROJECT_ID,
-            retry=DEFAULT,
-            timeout=None,
-        )
+        with pytest.raises(AirflowProviderDeprecationWarning, match=self.expected_deprecation_warning):
+            _ = AutoMLTablesListTableSpecsOperator(
+                dataset_id=DATASET_ID,
+                location=GCP_LOCATION,
+                project_id=GCP_PROJECT_ID,
+                filter_=filter_,
+                page_size=page_size,
+                task_id=TASK_ID,
+            )
+        mock_hook.assert_not_called()
 
     @pytest.mark.db_test
     def test_templating(self, create_task_instance_of_operator):
-        ti = create_task_instance_of_operator(
-            AutoMLTablesListTableSpecsOperator,
-            # Templated fields
-            dataset_id="{{ 'dataset-id' }}",
-            filter_="{{ 'filter-' }}",
-            location="{{ 'location' }}",
-            project_id="{{ 'project-id' }}",
-            impersonation_chain="{{ 'impersonation-chain' }}",
-            # Other parameters
-            dag_id="test_template_body_templating_dag",
-            task_id="test_template_body_templating_task",
-            execution_date=timezone.datetime(2024, 2, 1, tzinfo=timezone.utc),
-        )
-        ti.render_templates()
-        task: AutoMLTablesListTableSpecsOperator = ti.task
-        assert task.dataset_id == "dataset-id"
-        assert task.filter_ == "filter-"
-        assert task.location == "location"
-        assert task.project_id == "project-id"
-        assert task.impersonation_chain == "impersonation-chain"
+        with pytest.raises(AirflowProviderDeprecationWarning, match=self.expected_deprecation_warning):
+            _ = create_task_instance_of_operator(
+                AutoMLTablesListTableSpecsOperator,
+                # Templated fields
+                dataset_id="{{ 'dataset-id' }}",
+                filter_="{{ 'filter-' }}",
+                location="{{ 'location' }}",
+                project_id="{{ 'project-id' }}",
+                impersonation_chain="{{ 'impersonation-chain' }}",
+                # Other parameters
+                dag_id="test_template_body_templating_dag",
+                task_id="test_template_body_templating_task",
+                execution_date=timezone.datetime(2024, 2, 1, tzinfo=timezone.utc),
+            )
 
 
 class TestAutoMLDatasetListOperator:

--- a/tests/system/providers/google/cloud/automl/example_automl_translation.py
+++ b/tests/system/providers/google/cloud/automl/example_automl_translation.py
@@ -15,9 +15,8 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-"""
-Example Airflow DAG that uses Google AutoML services.
-"""
+
+"""Example Airflow DAG that uses Google AutoML Translation services."""
 
 from __future__ import annotations
 
@@ -31,7 +30,6 @@ from google.cloud import storage  # type: ignore[attr-defined]
 from airflow.decorators import task
 from airflow.models.dag import DAG
 from airflow.models.xcom_arg import XComArg
-from airflow.providers.google.cloud.hooks.automl import CloudAutoMLHook
 from airflow.providers.google.cloud.operators.automl import (
     AutoMLCreateDatasetOperator,
     AutoMLDeleteDatasetOperator,
@@ -43,7 +41,7 @@ from airflow.providers.google.cloud.operators.gcs import GCSCreateBucketOperator
 from airflow.providers.google.cloud.transfers.gcs_to_gcs import GCSToGCSOperator
 from airflow.utils.trigger_rule import TriggerRule
 
-DAG_ID = "example_automl_translate"
+DAG_ID = "automl_translate"
 GCP_PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 GCP_AUTOML_LOCATION = "us-central1"
@@ -57,7 +55,7 @@ MODEL = {
     "translation_model_metadata": {},
 }
 
-DATASET_NAME = f"ds_translate_{ENV_ID}".replace("-", "_")
+DATASET_NAME = f"ds_{DAG_ID}_{ENV_ID}".replace("-", "_")
 DATASET = {
     "display_name": DATASET_NAME,
     "translation_dataset_metadata": {
@@ -72,8 +70,6 @@ GCS_FILE_PATH = f"automl/datasets/translate/{CSV_FILE_NAME}"
 AUTOML_DATASET_BUCKET = f"gs://{DATA_SAMPLE_GCS_BUCKET_NAME}/automl/{CSV_FILE_NAME}"
 IMPORT_INPUT_CONFIG = {"gcs_source": {"input_uris": [AUTOML_DATASET_BUCKET]}}
 
-extract_object_id = CloudAutoMLHook.extract_object_id
-
 
 # Example DAG for AutoML Translation
 with DAG(
@@ -81,7 +77,6 @@ with DAG(
     schedule="@once",
     start_date=datetime(2021, 1, 1),
     catchup=False,
-    user_defined_macros={"extract_object_id": extract_object_id},
     tags=["example", "automl", "translate"],
 ) as dag:
     create_bucket = GCSCreateBucketOperator(


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Deprecate `AutoMLTablesListTableSpecsOperator` and `AutoMLTablesListColumnSpecsOperator`, update related tests.

Both `AutoMLTablesListTableSpecsOperator` and `AutoMLTablesListColumnSpecsOperator` are trying to make operations on AutoML datasets, such as getting specs of the tables contained withing the datasets, or of the tables' columns. However after its deprecation, the only available functionality in AutoML is AutoML Translation, which is integrated into Google Translation and does not support tabular datasets. So we can query the datasets with the operators, but no tables and their columns will be found making these operators useless and prone to errors.

Tabular datasets are available in Vertex AI, but unfortunately at this moment we do not have Vertex AI operators with similar functions.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
