### PR TITLE
Fix replace parameter for BigQueryToPostgresOperator

### DIFF
--- a/airflow/providers/google/cloud/transfers/bigquery_to_postgres.py
+++ b/airflow/providers/google/cloud/transfers/bigquery_to_postgres.py
@@ -19,13 +19,30 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+from airflow.providers.google.cloud.hooks.bigquery import BigQueryHook
 from airflow.providers.google.cloud.transfers.bigquery_to_sql import BigQueryToSqlBaseOperator
+from airflow.providers.google.cloud.utils.bigquery_get_data import bigquery_get_data
 from airflow.providers.postgres.hooks.postgres import PostgresHook
+
+if TYPE_CHECKING:
+    from airflow.utils.context import Context
 
 
 class BigQueryToPostgresOperator(BigQueryToSqlBaseOperator):
     """
     Fetch data from a BigQuery table (alternatively fetch selected columns) and insert into PostgreSQL table.
+
+    Due to constraints of the PostgreSQL's ON CONFLICT clause both `selected_fields` and `replace_index`
+    parameters need to be specified when using the operator with parameter `replace=True`.
+    In effect this means that in order to run this operator with `replace=True` your target table MUST
+    already have a unique index column / columns, otherwise the INSERT command will fail with an error.
+    See more at https://www.postgresql.org/docs/current/sql-insert.html.
+
+    Please note that currently most of the clauses that can be used with PostgreSQL's INSERT
+    command, such as ON CONSTRAINT, WHERE, DEFAULT, etc.,  are not supported by this operator.
+    If you need the clauses for your queries, `SQLExecuteQueryOperator` will be a more suitable option.
 
     .. seealso::
         For more information on how to use this operator, take a look at the guide:
@@ -33,6 +50,11 @@ class BigQueryToPostgresOperator(BigQueryToSqlBaseOperator):
 
     :param target_table_name: target Postgres table (templated)
     :param postgres_conn_id: Reference to :ref:`postgres connection id <howto/connection:postgres>`.
+    :param replace: Whether to replace instead of insert
+    :param selected_fields: List of fields to return (comma-separated). If
+        unspecified, all fields are returned. Must be specified if `replace` is True
+    :param replace_index: the column or list of column names to act as
+        index for the ON CONFLICT clause. Must be specified if `replace` is True
     """
 
     def __init__(
@@ -40,10 +62,43 @@ class BigQueryToPostgresOperator(BigQueryToSqlBaseOperator):
         *,
         target_table_name: str,
         postgres_conn_id: str = "postgres_default",
+        replace: bool = False,
+        selected_fields: list[str] | str | None = None,
+        replace_index: list[str] | str | None = None,
         **kwargs,
     ) -> None:
-        super().__init__(target_table_name=target_table_name, **kwargs)
+        if replace and not (selected_fields and replace_index):
+            raise ValueError("PostgreSQL ON CONFLICT upsert syntax requires column names and a unique index.")
+        super().__init__(
+            target_table_name=target_table_name, replace=replace, selected_fields=selected_fields, **kwargs
+        )
         self.postgres_conn_id = postgres_conn_id
+        self.replace_index = replace_index
 
     def get_sql_hook(self) -> PostgresHook:
         return PostgresHook(schema=self.database, postgres_conn_id=self.postgres_conn_id)
+
+    def execute(self, context: Context) -> None:
+        big_query_hook = BigQueryHook(
+            gcp_conn_id=self.gcp_conn_id,
+            location=self.location,
+            impersonation_chain=self.impersonation_chain,
+        )
+        self.persist_links(context)
+        sql_hook: PostgresHook = self.get_sql_hook()
+        for rows in bigquery_get_data(
+            self.log,
+            self.dataset_id,
+            self.table_id,
+            big_query_hook,
+            self.batch_size,
+            self.selected_fields,
+        ):
+            sql_hook.insert_rows(
+                table=self.target_table_name,
+                rows=rows,
+                target_fields=self.selected_fields,
+                replace=self.replace,
+                commit_every=self.batch_size,
+                replace_index=self.replace_index,
+            )

--- a/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_postgres.rst
+++ b/docs/apache-airflow-providers-google/operators/transfer/bigquery_to_postgres.rst
@@ -44,6 +44,10 @@ to define values dynamically.
 
 You may use the parameter ``selected_fields`` to limit the fields to be copied (all fields by default),
 as well as the parameter ``replace`` to overwrite the destination table instead of appending to it.
+If the ``replace`` parameter is used, then both ``selected_fields`` and ``replace_index``parameters will
+need to be specified due to constraints of the PostgreSQL's ON CONFLICT clause in the underlying INSERT
+command.
+
 For more information, please refer to the links above.
 
 Transferring data
@@ -56,6 +60,14 @@ The following Operator copies data from a BigQuery table to PostgreSQL.
     :dedent: 4
     :start-after: [START howto_operator_bigquery_to_postgres]
     :end-before: [END howto_operator_bigquery_to_postgres]
+
+The Operator can also replace data in a PostgreSQL table with matching data from a BigQuery table.
+
+.. exampleinclude:: /../../tests/system/providers/google/cloud/bigquery/example_bigquery_to_postgres.py
+    :language: python
+    :dedent: 4
+    :start-after: [START howto_operator_bigquery_to_postgres_upsert]
+    :end-before: [END howto_operator_bigquery_to_postgres_upsert]
 
 
 Reference


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

Add a required missing parameter `replace_index` to `BigQueryToPostgresOperator` and documentation explaining how to use the operator when the `replace` parameter is set to _True_.

Fixes a problem where it was impossible to run  `BigQueryToPostgresOperator` because of the underlying `PostgresHook._generate_insert_sql()` method that required both `selected_fields` and `replace_index` parameters to be set the `replace` parameter was _True_.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
