### PR TITLE
Enforce deprecation message format with EOL for google provider package

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1034,6 +1034,7 @@ repos:
         pass_filenames: true
         files: ^airflow/.*\.py$
         exclude: ^.*/.*_vendor/
+        additional_dependencies: ["rich>=12.4.4", "python-dateutil"]
       - id: lint-chart-schema
         name: Lint chart/values.schema.json file
         entry: ./scripts/ci/pre_commit/chart_schema.py

--- a/airflow/providers/google/cloud/hooks/bigquery.py
+++ b/airflow/providers/google/cloud/hooks/bigquery.py
@@ -175,10 +175,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
 
     @cached_property
     @deprecated(
-        reason=(
-            "`BigQueryHook.credentials_path` property is deprecated and will be removed in the future. "
-            "This property used for obtaining credentials path but no longer in actual use. "
-        ),
+        reason="The credentials_path property is deprecated and will be removed after 01.11.2024. "
+        "There is no replacement because this property used for obtaining credentials path "
+        "but is no longer in actual use. ",
         category=AirflowProviderDeprecationWarning,
     )
     def credentials_path(self) -> str:
@@ -198,7 +197,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         )
 
     @deprecated(
-        reason=("Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_client`"),
+        reason="The get_service method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_client method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_service(self) -> Resource:
@@ -604,10 +604,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         )
 
     @deprecated(
-        reason=(
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table` "
-            "method with passing the `table_resource` object. This gives more flexibility than this method."
-        ),
+        reason="The create_external_table method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table method "
+        "with passing the table_resource object instead. This gives more flexibility than this method.",
         category=AirflowProviderDeprecationWarning,
     )
     @GoogleBaseHook.fallback_to_default_project_id
@@ -806,9 +805,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         return table_object.to_api_repr()
 
     @deprecated(
-        reason=(
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_table` method."
-        ),
+        reason="The patch_table method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_table method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     @GoogleBaseHook.fallback_to_default_project_id
@@ -1017,9 +1015,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         return dataset
 
     @deprecated(
-        reason=(
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_dataset` method."
-        ),
+        reason="The patch_dataset method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_dataset "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def patch_dataset(
@@ -1065,9 +1063,9 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         return dataset
 
     @deprecated(
-        reason=(
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables` method."
-        ),
+        reason="The get_dataset_tables_list method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_dataset_tables_list(
@@ -1271,9 +1269,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         return table
 
     @deprecated(
-        reason=(
-            "Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.delete_table` method."
-        ),
+        reason="The run_table_delete method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.delete_table method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def run_table_delete(self, deletion_dataset_table: str, ignore_if_missing: bool = False) -> None:
@@ -1320,7 +1317,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         self.log.info("Deleted table %s", table_id)
 
     @deprecated(
-        reason=("Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.list_rows` method."),
+        reason="The get_tabledata method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.list_rows method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_tabledata(
@@ -1556,7 +1554,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         return job.done(retry=retry)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.cancel_job`",
+        reason="The cancel_query method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.cancel_job method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def cancel_query(self) -> None:
@@ -1709,7 +1708,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         return job_api_repr
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job`",
+        reason="The run_with_configuration method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def run_with_configuration(self, configuration: dict) -> str:
@@ -1730,7 +1730,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         return job.job_id
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job`",
+        reason="The run_load method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def run_load(
@@ -1971,7 +1972,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         return job.job_id
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job`",
+        reason="The run_copy method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def run_copy(
@@ -2057,7 +2059,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         return job.job_id
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job`",
+        reason="The run_extract method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def run_extract(
@@ -2131,7 +2134,8 @@ class BigQueryHook(GoogleBaseHook, DbApiHook):
         return job.job_id
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job`",
+        reason="The run_query method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_job method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def run_query(
@@ -2548,7 +2552,9 @@ class BigQueryBaseCursor(LoggingMixin):
         self.hook = hook
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table`",
+        reason="The create_empty_table method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_table "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def create_empty_table(self, *args, **kwargs):
@@ -2561,7 +2567,9 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.create_empty_table(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_dataset`",
+        reason="The create_empty_dataset method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_empty_dataset "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def create_empty_dataset(self, *args, **kwargs) -> dict[str, Any]:
@@ -2574,7 +2582,9 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.create_empty_dataset(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables`",
+        reason="The get_dataset_tables method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_dataset_tables(self, *args, **kwargs) -> list[dict[str, Any]]:
@@ -2587,7 +2597,9 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.get_dataset_tables(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.delete_dataset`",
+        reason="The delete_dataset method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.delete_dataset "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def delete_dataset(self, *args, **kwargs) -> None:
@@ -2600,7 +2612,9 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.delete_dataset(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_external_table`",
+        reason="The create_external_table method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.create_external_table "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def create_external_table(self, *args, **kwargs):
@@ -2613,7 +2627,8 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.create_external_table(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.patch_table`",
+        reason="The patch_table method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.patch_table method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def patch_table(self, *args, **kwargs) -> None:
@@ -2626,7 +2641,8 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.patch_table(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_all`",
+        reason="The insert_all method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.insert_all method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def insert_all(self, *args, **kwargs) -> None:
@@ -2639,7 +2655,9 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.insert_all(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_dataset`",
+        reason="The update_dataset method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.update_dataset "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def update_dataset(self, *args, **kwargs) -> dict:
@@ -2652,7 +2670,8 @@ class BigQueryBaseCursor(LoggingMixin):
         return Dataset.to_api_repr(self.hook.update_dataset(*args, **kwargs))
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.patch_dataset`",
+        reason="The patch_dataset method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.patch_dataset method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def patch_dataset(self, *args, **kwargs) -> dict:
@@ -2665,7 +2684,9 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.patch_dataset(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables_list`",
+        reason="The get_dataset_tables_list method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset_tables_list "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_dataset_tables_list(self, *args, **kwargs) -> list[dict[str, Any]]:
@@ -2678,7 +2699,9 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.get_dataset_tables_list(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_datasets_list`",
+        reason="The get_datasets_list method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_datasets_list "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_datasets_list(self, *args, **kwargs) -> list | HTTPIterator:
@@ -2691,7 +2714,8 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.get_datasets_list(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset`",
+        reason="The get_dataset method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_dataset method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_dataset(self, *args, **kwargs) -> Dataset:
@@ -2704,7 +2728,9 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.get_dataset(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_grant_dataset_view_access`",
+        reason="The run_grant_dataset_view_access method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_grant_dataset_view_access "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def run_grant_dataset_view_access(self, *args, **kwargs) -> dict:
@@ -2718,7 +2744,9 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.run_grant_dataset_view_access(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_table_upsert`",
+        reason="The run_table_upsert method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_table_upsert "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def run_table_upsert(self, *args, **kwargs) -> dict:
@@ -2731,7 +2759,9 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.run_table_upsert(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_table_delete`",
+        reason="The run_table_delete method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_table_delete "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def run_table_delete(self, *args, **kwargs) -> None:
@@ -2744,7 +2774,8 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.run_table_delete(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_tabledata`",
+        reason="The get_tabledata method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_tabledata method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_tabledata(self, *args, **kwargs) -> list[dict]:
@@ -2757,7 +2788,8 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.get_tabledata(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_schema`",
+        reason="The get_schema method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.get_schema method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_schema(self, *args, **kwargs) -> dict:
@@ -2770,7 +2802,9 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.get_schema(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.poll_job_complete`",
+        reason="The poll_job_complete method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.poll_job_complete "
+        "method instead",
         category=AirflowProviderDeprecationWarning,
     )
     def poll_job_complete(self, *args, **kwargs) -> bool:
@@ -2783,7 +2817,8 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.poll_job_complete(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.cancel_query`",
+        reason="The cancel_query method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.cancel_query method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def cancel_query(self, *args, **kwargs) -> None:
@@ -2796,7 +2831,9 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.cancel_query(*args, **kwargs)  # type: ignore
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration`",
+        reason="The run_with_configuration method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_with_configuration "
+        "method instead",
         category=AirflowProviderDeprecationWarning,
     )
     def run_with_configuration(self, *args, **kwargs) -> str:
@@ -2809,7 +2846,8 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.run_with_configuration(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_load`",
+        reason="The run_load method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_load method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def run_load(self, *args, **kwargs) -> str:
@@ -2822,7 +2860,8 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.run_load(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_copy`",
+        reason="The run_copy method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_copy method instead",
         category=AirflowProviderDeprecationWarning,
     )
     def run_copy(self, *args, **kwargs) -> str:
@@ -2835,7 +2874,8 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.run_copy(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_extract`",
+        reason="The run_extract method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_extract method instead",
         category=AirflowProviderDeprecationWarning,
     )
     def run_extract(self, *args, **kwargs) -> str | BigQueryJob:
@@ -2848,7 +2888,8 @@ class BigQueryBaseCursor(LoggingMixin):
         return self.hook.run_extract(*args, **kwargs)
 
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_query`",
+        reason="The run_query method is deprecated and will be removed after 01.11.2024. "
+        "Please use airflow.providers.google.cloud.hooks.bigquery.BigQueryHook.run_query instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def run_query(self, *args, **kwargs) -> str:

--- a/airflow/providers/google/cloud/hooks/cloud_build.py
+++ b/airflow/providers/google/cloud/hooks/cloud_build.py
@@ -191,7 +191,8 @@ class CloudBuildHook(GoogleBaseHook):
 
     @GoogleBaseHook.fallback_to_default_project_id
     @deprecated(
-        reason="Please use `create_build_without_waiting_for_result`",
+        reason="The create_build method is deprecated and will be removed after 01.03.2025. "
+        "Please use create_build_without_waiting_for_result method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def create_build(

--- a/airflow/providers/google/cloud/hooks/dataflow.py
+++ b/airflow/providers/google/cloud/hooks/dataflow.py
@@ -594,12 +594,10 @@ class DataflowHook(GoogleBaseHook):
     @_fallback_to_project_id_from_variables
     @GoogleBaseHook.fallback_to_default_project_id
     @deprecated(
-        reason=(
-            "This method is deprecated. "
-            "Please use `airflow.providers.apache.beam.hooks.beam.start.start_java_pipeline` "
-            "to start pipeline and `providers.google.cloud.hooks.dataflow.DataflowHook.wait_for_done` "
-            "to wait for the required pipeline state."
-        ),
+        reason="The start_java_dataflow method is deprecated and will be removed after 01.03.2025. "
+        "Please use airflow.providers.apache.beam.hooks.beam.start.start_java_pipeline method "
+        "to start pipeline and providers.google.cloud.hooks.dataflow.DataflowHook.wait_for_done method "
+        "to wait for the required pipeline state instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def start_java_dataflow(
@@ -951,12 +949,10 @@ class DataflowHook(GoogleBaseHook):
     @_fallback_to_project_id_from_variables
     @GoogleBaseHook.fallback_to_default_project_id
     @deprecated(
-        reason=(
-            "This method is deprecated. "
-            "Please use `airflow.providers.apache.beam.hooks.beam.start.start_python_pipeline` "
-            "to start pipeline and `providers.google.cloud.hooks.dataflow.DataflowHook.wait_for_done` "
-            "to wait for the required pipeline state."
-        ),
+        reason="The start_python_dataflow method is deprecated and will be removed after 01.03.2025. "
+        "Please use airflow.providers.apache.beam.hooks.beam.start.start_python_pipeline method "
+        "to start pipeline and providers.google.cloud.hooks.dataflow.DataflowHook.wait_for_done method "
+        "to wait for the required pipeline state instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def start_python_dataflow(

--- a/airflow/providers/google/cloud/hooks/datapipeline.py
+++ b/airflow/providers/google/cloud/hooks/datapipeline.py
@@ -34,7 +34,8 @@ DEFAULT_DATAPIPELINE_LOCATION = "us-central1"
 
 
 @deprecated(
-    reason="This hook is deprecated and will be removed after 01.12.2024. Please use `DataflowHook`.",
+    reason="The DataPipelineHook is deprecated and will be removed after 01.12.2024. "
+    "Please use DataflowHook instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class DataPipelineHook(DataflowHook):

--- a/airflow/providers/google/cloud/hooks/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/hooks/kubernetes_engine.py
@@ -139,10 +139,8 @@ class GKEHook(GoogleBaseHook):
     # To preserve backward compatibility
     # TODO: remove one day
     @deprecated(
-        reason=(
-            "The get_conn method has been deprecated. "
-            "You should use the get_cluster_manager_client method."
-        ),
+        reason="The get_conn method is deprecated and will be removed after 01.11.2024. "
+        "Please use the get_cluster_manager_client method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_conn(self) -> container_v1.ClusterManagerClient:
@@ -151,7 +149,8 @@ class GKEHook(GoogleBaseHook):
     # To preserve backward compatibility
     # TODO: remove one day
     @deprecated(
-        reason="The get_client method has been deprecated. You should use the get_conn method.",
+        reason="The get_client method is deprecated and will be removed after 01.11.2024. "
+        "Please use the get_conn method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_client(self) -> ClusterManagerClient:
@@ -580,10 +579,8 @@ class GKEKubernetesAsyncHook(GoogleBaseAsyncHook, AsyncKubernetesHook):
 
 
 @deprecated(
-    reason=(
-        "The `GKEDeploymentHook` class is deprecated and will be removed after 01.10.2024, please use "
-        "`GKEKubernetesHook` instead."
-    ),
+    reason="The GKEDeploymentHook class is deprecated and will be removed after 01.10.2024. "
+    "Please use GKEKubernetesHook instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class GKEDeploymentHook(GKEKubernetesHook):
@@ -591,10 +588,8 @@ class GKEDeploymentHook(GKEKubernetesHook):
 
 
 @deprecated(
-    reason=(
-        "The `GKECustomResourceHook` class is deprecated and will be removed after 01.10.2024, please use "
-        "`GKEKubernetesHook` instead."
-    ),
+    reason="The GKECustomResourceHook class is deprecated and will be removed after 01.10.2024. "
+    "Please use GKEKubernetesHook instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class GKECustomResourceHook(GKEKubernetesHook):
@@ -602,10 +597,8 @@ class GKECustomResourceHook(GKEKubernetesHook):
 
 
 @deprecated(
-    reason=(
-        "The `GKEPodHook` class is deprecated and will be removed after 01.10.2024, please use "
-        "`GKEKubernetesHook` instead."
-    ),
+    reason="The GKEPodHook class is deprecated and will be removed after 01.10.2024. "
+    "Please use GKEKubernetesHook instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class GKEPodHook(GKEKubernetesHook):
@@ -631,10 +624,8 @@ class GKEPodHook(GKEKubernetesHook):
 
 
 @deprecated(
-    reason=(
-        "The `GKEJobHook` class is deprecated and will be removed after 01.10.2024, please use "
-        "`GKEKubernetesHook` instead."
-    ),
+    reason="The GKEJobHook class is deprecated and will be removed after 01.10.2024. "
+    "Please use GKEKubernetesHook instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class GKEJobHook(GKEKubernetesHook):
@@ -642,10 +633,8 @@ class GKEJobHook(GKEKubernetesHook):
 
 
 @deprecated(
-    reason=(
-        "The `GKEPodAsyncHook` class is deprecated and will be removed after 01.10.2024, please use "
-        "`GKEKubernetesAsyncHook` instead."
-    ),
+    reason="The GKEPodAsyncHook class is deprecated and will be removed after 01.10.2024. "
+    "Please use GKEKubernetesAsyncHook instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class GKEPodAsyncHook(GKEKubernetesAsyncHook):

--- a/airflow/providers/google/cloud/hooks/life_sciences.py
+++ b/airflow/providers/google/cloud/hooks/life_sciences.py
@@ -34,12 +34,10 @@ TIME_TO_SLEEP_IN_SECONDS = 5
 
 
 @deprecated(
-    reason=(
-        "This hook is deprecated. Consider using "
-        "Google Cloud Batch Operators' hook instead. "
-        "The Life Sciences API (beta) will be discontinued "
-        "on July 8, 2025 in favor of Google Cloud Batch."
-    ),
+    reason="The LifeSciencesHook is deprecated and will be removed after 08.07.2024. "
+    "Please use  Google Cloud Batch Operators' hook instead. "
+    "The Life Sciences API (beta) will be discontinued "
+    "on July 8, 2025 in favor of Google Cloud Batch.",
     category=AirflowProviderDeprecationWarning,
 )
 class LifeSciencesHook(GoogleBaseHook):

--- a/airflow/providers/google/cloud/hooks/vertex_ai/custom_job.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/custom_job.py
@@ -380,7 +380,8 @@ class CustomJobHook(GoogleBaseHook):
 
     @GoogleBaseHook.fallback_to_default_project_id
     @deprecated(
-        reason="Please use `PipelineJobHook.cancel_pipeline_job`",
+        reason="The cancel_pipeline_job method is deprecated and will be removed after 01.03.2025. "
+        "Please use PipelineJobHook.cancel_pipeline_job method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def cancel_pipeline_job(
@@ -509,7 +510,8 @@ class CustomJobHook(GoogleBaseHook):
 
     @GoogleBaseHook.fallback_to_default_project_id
     @deprecated(
-        reason="Please use `PipelineJobHook.create_pipeline_job`",
+        reason="The create_pipeline_job method is deprecated and will be removed after 01.03.2025. "
+        "Please use PipelineJobHook.create_pipeline_job method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def create_pipeline_job(
@@ -2980,7 +2982,8 @@ class CustomJobHook(GoogleBaseHook):
 
     @GoogleBaseHook.fallback_to_default_project_id
     @deprecated(
-        reason="Please use `PipelineJobHook.get_pipeline_job`",
+        reason="The get_pipeline_job method is deprecated and will be removed after 01.03.2025. "
+        "Please use PipelineJobHook.get_pipeline_job method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_pipeline_job(
@@ -3085,7 +3088,8 @@ class CustomJobHook(GoogleBaseHook):
 
     @GoogleBaseHook.fallback_to_default_project_id
     @deprecated(
-        reason="Please use `PipelineJobHook.list_pipeline_jobs`",
+        reason="The list_pipeline_jobs method is deprecated and will be removed after 01.03.2025. "
+        "Please use PipelineJobHook.list_pipeline_jobs method instead",
         category=AirflowProviderDeprecationWarning,
     )
     def list_pipeline_jobs(
@@ -3301,7 +3305,8 @@ class CustomJobHook(GoogleBaseHook):
 
     @GoogleBaseHook.fallback_to_default_project_id
     @deprecated(
-        reason="Please use `PipelineJobHook.delete_pipeline_job`",
+        reason="The delete_pipeline_job method is deprecated and will be removed after 01.03.2025. "
+        "Please use PipelineJobHook.delete_pipeline_job method instead",
         category=AirflowProviderDeprecationWarning,
     )
     def delete_pipeline_job(

--- a/airflow/providers/google/cloud/hooks/vertex_ai/generative_model.py
+++ b/airflow/providers/google/cloud/hooks/vertex_ai/generative_model.py
@@ -62,9 +62,10 @@ class GenerativeModelHook(GoogleBaseHook):
         return model
 
     @deprecated(
-        reason=(
-            "The `get_generative_model_part` method is deprecated and will be removed after 01.01.2025, please include `Part` objects in `contents` parameter of `airflow.providers.google.cloud.hooks.generative_model.GenerativeModelHook.generative_model_generate_content`"
-        ),
+        reason="The get_generative_model_part method is deprecated and will be removed after 01.01.2025. "
+        "Please use Part objects included in contents parameter of "
+        "airflow.providers.google.cloud.hooks.generative_model.GenerativeModelHook.generative_model_generate_content "
+        "instead",
         category=AirflowProviderDeprecationWarning,
     )
     def get_generative_model_part(self, content_gcs_path: str, content_mime_type: str | None = None) -> Part:
@@ -73,9 +74,9 @@ class GenerativeModelHook(GoogleBaseHook):
         return part
 
     @deprecated(
-        reason=(
-            "The `prompt_language_model` method is deprecated and will be removed after 01.01.2025, please use `airflow.providers.google.cloud.hooks.generative_model.GenerativeModelHook.text_generation_model_predict` method."
-        ),
+        reason="The prompt_language_model method is deprecated and will be removed after 01.01.2025. "
+        "Please use airflow.providers.google.cloud.hooks.generative_model.GenerativeModelHook.text_generation_model_predict "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     @GoogleBaseHook.fallback_to_default_project_id
@@ -127,9 +128,9 @@ class GenerativeModelHook(GoogleBaseHook):
         return response.text
 
     @deprecated(
-        reason=(
-            "The `generate_text_embeddings` method is deprecated and will be removed after 01.01.2025, please use `airflow.providers.google.cloud.hooks.generative_model.GenerativeModelHook.text_embedding_model_get_embeddings` method."
-        ),
+        reason="The generate_text_embeddings method is deprecated and will be removed after 01.01.2025. "
+        "Please use airflow.providers.google.cloud.hooks.generative_model.GenerativeModelHook.text_embedding_model_get_embeddings "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     @GoogleBaseHook.fallback_to_default_project_id
@@ -157,9 +158,9 @@ class GenerativeModelHook(GoogleBaseHook):
         return response.values
 
     @deprecated(
-        reason=(
-            "The `prompt_multimodal_model` method is deprecated and will be removed after 01.01.2025, please use `airflow.providers.google.cloud.hooks.generative_model.GenerativeModelHook.generative_model_generate_content` method."
-        ),
+        reason="The prompt_multimodal_model method is deprecated and will be removed after 01.01.2025. "
+        "Please use airflow.providers.google.cloud.hooks.generative_model.GenerativeModelHook.generative_model_generate_content "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     @GoogleBaseHook.fallback_to_default_project_id
@@ -196,9 +197,10 @@ class GenerativeModelHook(GoogleBaseHook):
         return response.text
 
     @deprecated(
-        reason=(
-            "The `prompt_multimodal_model_with_media` method is deprecated and will be removed after 01.01.2025, please use `airflow.providers.google.cloud.hooks.generative_model.GenerativeModelHook.generative_model_generate_content` method."
-        ),
+        reason="The prompt_multimodal_model_with_media method is deprecated "
+        "and will be removed after 01.01.2025. Please use "
+        "airflow.providers.google.cloud.hooks.generative_model.GenerativeModelHook.generative_model_generate_content "
+        "method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     @GoogleBaseHook.fallback_to_default_project_id

--- a/airflow/providers/google/cloud/links/automl.py
+++ b/airflow/providers/google/cloud/links/automl.py
@@ -48,10 +48,9 @@ AUTOML_MODEL_PREDICT_LINK = (
 
 
 @deprecated(
-    reason=(
-        "Class `AutoMLDatasetLink` has been deprecated and will be removed after 31.12.2024. "
-        "Please use `TranslationLegacyDatasetLink` from `airflow/providers/google/cloud/links/translate.py` instead."
-    ),
+    reason="The AutoMLDatasetLink class is deprecated and will be removed after 31.12.2024. "
+    "Please use TranslationLegacyDatasetLink class from "
+    "airflow/providers/google/cloud/links/translate.py instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class AutoMLDatasetLink(BaseGoogleLink):
@@ -76,10 +75,9 @@ class AutoMLDatasetLink(BaseGoogleLink):
 
 
 @deprecated(
-    reason=(
-        "Class `AutoMLDatasetListLink` has been deprecated and will be removed after 31.12.2024. "
-        "Please use `TranslationDatasetListLink` from `airflow/providers/google/cloud/links/translate.py` instead."
-    ),
+    reason="The AutoMLDatasetListLink class is deprecated and will be removed after 31.12.2024. "
+    "Please use TranslationDatasetListLink class from "
+    "airflow/providers/google/cloud/links/translate.py instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class AutoMLDatasetListLink(BaseGoogleLink):
@@ -105,10 +103,9 @@ class AutoMLDatasetListLink(BaseGoogleLink):
 
 
 @deprecated(
-    reason=(
-        "Class `AutoMLModelLink` has been deprecated and will be removed after 31.12.2024. "
-        "Please use `TranslationLegacyModelLink` from `airflow/providers/google/cloud/links/translate.py` instead."
-    ),
+    reason="The AutoMLModelLink class is deprecated and will be removed after 31.12.2024. "
+    "Please use TranslationLegacyModelLink class from "
+    "airflow/providers/google/cloud/links/translate.py instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class AutoMLModelLink(BaseGoogleLink):
@@ -139,10 +136,9 @@ class AutoMLModelLink(BaseGoogleLink):
 
 
 @deprecated(
-    reason=(
-        "Class `AutoMLModelTrainLink` has been deprecated and will be removed after 31.12.2024. "
-        "Please use `TranslationLegacyModelTrainLink` from `airflow/providers/google/cloud/links/translate.py` instead."
-    ),
+    reason="The AutoMLModelTrainLink class is deprecated and will be removed after 31.12.2024. "
+    "Please use TranslationLegacyModelTrainLink class from "
+    "airflow/providers/google/cloud/links/translate.py instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class AutoMLModelTrainLink(BaseGoogleLink):
@@ -170,10 +166,9 @@ class AutoMLModelTrainLink(BaseGoogleLink):
 
 
 @deprecated(
-    reason=(
-        "Class `AutoMLModelPredictLink` has been deprecated and will be removed after 31.12.2024. "
-        "Please use `TranslationLegacyModelPredictLink` from `airflow/providers/google/cloud/links/translate.py` instead."
-    ),
+    reason="The AutoMLModelPredictLink class is deprecated and will be removed after 31.12.2024. "
+    "Please use TranslationLegacyModelPredictLink class from "
+    "airflow/providers/google/cloud/links/translate.py instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class AutoMLModelPredictLink(BaseGoogleLink):

--- a/airflow/providers/google/cloud/operators/bigquery.py
+++ b/airflow/providers/google/cloud/operators/bigquery.py
@@ -1203,7 +1203,8 @@ class BigQueryGetDataOperator(GoogleCloudBaseOperator, _BigQueryOperatorsEncrypt
 
 
 @deprecated(
-    reason="This operator is deprecated. Please use `BigQueryInsertJobOperator`.",
+    reason="The BigQueryExecuteQueryOperator is deprecated and will be removed after 01.11.2024. "
+    "Please use BigQueryInsertJobOperator instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class BigQueryExecuteQueryOperator(GoogleCloudBaseOperator):
@@ -2298,7 +2299,8 @@ class BigQueryGetDatasetTablesOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason="This operator is deprecated. Please use BigQueryUpdateDatasetOperator.",
+    reason="The BigQueryPatchDatasetOperator is deprecated and will be removed after 01.11.2024. "
+    "Please use BigQueryUpdateDatasetOperator instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class BigQueryPatchDatasetOperator(GoogleCloudBaseOperator):

--- a/airflow/providers/google/cloud/operators/dataflow.py
+++ b/airflow/providers/google/cloud/operators/dataflow.py
@@ -174,7 +174,8 @@ class DataflowConfiguration:
 
 # TODO: Remove one day
 @deprecated(
-    reason="Please use `providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator` instead.",
+    reason="The DataflowCreateJavaJobOperator class is deprecated and will be removed after 01.11.2024. "
+    "Please use providers.apache.beam.operators.beam.BeamRunJavaPipelineOperator class instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class DataflowCreateJavaJobOperator(GoogleCloudBaseOperator):
@@ -1052,7 +1053,8 @@ class DataflowStartSqlJobOperator(GoogleCloudBaseOperator):
 
 # TODO: Remove one day
 @deprecated(
-    reason="Please use `providers.apache.beam.operators.beam.BeamRunPythonPipelineOperator` instead.",
+    reason="The DataflowCreatePythonJobOperator class is deprecated and will be removed after 01.11.2024. "
+    "Please use providers.apache.beam.operators.beam.BeamRunPythonPipelineOperator class instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class DataflowCreatePythonJobOperator(GoogleCloudBaseOperator):

--- a/airflow/providers/google/cloud/operators/datafusion.py
+++ b/airflow/providers/google/cloud/operators/datafusion.py
@@ -53,7 +53,8 @@ class DataFusionPipelineLinkHelper:
 
     @staticmethod
     @deprecated(
-        reason="Please use `airflow.providers.google.cloud.utils.helpers.resource_path_to_dict` instead.",
+        reason="The get_project_id method is deprecated and will be removed after 01.03.2025. "
+        "Please use airflow.providers.google.cloud.utils.helpers.resource_path_to_dict method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_project_id(instance):

--- a/airflow/providers/google/cloud/operators/datapipeline.py
+++ b/airflow/providers/google/cloud/operators/datapipeline.py
@@ -31,8 +31,8 @@ from airflow.providers.google.common.hooks.base_google import PROVIDE_PROJECT_ID
 
 
 @deprecated(
-    reason="This operator is deprecated and will be removed after 01.12.2024. "
-    "Please use `DataflowCreatePipelineOperator`.",
+    reason="The CreateDataPipelineOperator is deprecated and will be removed after 01.12.2024. "
+    "Please use DataflowCreatePipelineOperator class instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class CreateDataPipelineOperator(DataflowCreatePipelineOperator):
@@ -40,8 +40,8 @@ class CreateDataPipelineOperator(DataflowCreatePipelineOperator):
 
 
 @deprecated(
-    reason="This operator is deprecated and will be removed after 01.12.2024. "
-    "Please use `DataflowRunPipelineOperator`.",
+    reason="The RunDataPipelineOperator is deprecated and will be removed after 01.12.2024. "
+    "Please use DataflowRunPipelineOperator class instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class RunDataPipelineOperator(DataflowRunPipelineOperator):

--- a/airflow/providers/google/cloud/operators/dataproc.py
+++ b/airflow/providers/google/cloud/operators/dataproc.py
@@ -882,7 +882,8 @@ class DataprocCreateClusterOperator(GoogleCloudBaseOperator):
 
 # TODO: Remove one day
 @deprecated(
-    reason="Please use `DataprocUpdateClusterOperator` instead.",
+    reason="The DataprocScaleClusterOperator is deprecated and will be removed after 01.03.2025. "
+    "Please use DataprocUpdateClusterOperator class instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class DataprocScaleClusterOperator(GoogleCloudBaseOperator):
@@ -1505,11 +1506,10 @@ class DataprocJobBaseOperator(GoogleCloudBaseOperator):
 
 # TODO: Remove one day
 @deprecated(
-    reason=(
-        "Please use `DataprocSubmitJobOperator` instead. "
-        "You can use `generate_job` method to generate dictionary representing your job "
-        "and use it with the new operator."
-    ),
+    reason="The DataprocSubmitPigJobOperator is deprecated and will be removed after 01.11.2024. "
+    "Please use DataprocSubmitJobOperator class instead. "
+    "You can use `generate_job` method to generate dictionary representing your job "
+    "and use it with the new operator.",
     category=AirflowProviderDeprecationWarning,
 )
 class DataprocSubmitPigJobOperator(DataprocJobBaseOperator):
@@ -1632,11 +1632,10 @@ class DataprocSubmitPigJobOperator(DataprocJobBaseOperator):
 
 # TODO: Remove one day
 @deprecated(
-    reason=(
-        "Please use `DataprocSubmitJobOperator` instead. "
-        "You can use `generate_job` method to generate dictionary representing your job "
-        "and use it with the new operator."
-    ),
+    reason="The DataprocSubmitHiveJobOperator is deprecated and will be removed after 01.11.2024. "
+    "Please use DataprocSubmitJobOperator class instead. "
+    "You can use `generate_job` method to generate dictionary representing your job "
+    "and use it with the new operator.",
     category=AirflowProviderDeprecationWarning,
 )
 class DataprocSubmitHiveJobOperator(DataprocJobBaseOperator):
@@ -1725,11 +1724,10 @@ class DataprocSubmitHiveJobOperator(DataprocJobBaseOperator):
 
 # TODO: Remove one day
 @deprecated(
-    reason=(
-        "Please use `DataprocSubmitJobOperator` instead. "
-        "You can use `generate_job` method to generate dictionary representing your job "
-        "and use it with the new operator."
-    ),
+    reason="The DataprocSubmitSparkSqlJobOperator is deprecated and will be removed after 01.11.2024. "
+    "Please use DataprocSubmitJobOperator class instead. "
+    "You can use `generate_job` method to generate dictionary representing your job "
+    "and use it with the new operator.",
     category=AirflowProviderDeprecationWarning,
 )
 class DataprocSubmitSparkSqlJobOperator(DataprocJobBaseOperator):
@@ -1817,11 +1815,10 @@ class DataprocSubmitSparkSqlJobOperator(DataprocJobBaseOperator):
 
 # TODO: Remove one day
 @deprecated(
-    reason=(
-        "Please use `DataprocSubmitJobOperator` instead. "
-        "You can use `generate_job` method to generate dictionary representing your job "
-        "and use it with the new operator."
-    ),
+    reason="The DataprocSubmitSparkJobOperator is deprecated and will be removed after 01.11.2024. "
+    "Please use DataprocSubmitJobOperator class instead. "
+    "You can use `generate_job` method to generate dictionary representing your job "
+    "and use it with the new operator.",
     category=AirflowProviderDeprecationWarning,
 )
 class DataprocSubmitSparkJobOperator(DataprocJobBaseOperator):
@@ -1909,11 +1906,10 @@ class DataprocSubmitSparkJobOperator(DataprocJobBaseOperator):
 
 # TODO: Remove one day
 @deprecated(
-    reason=(
-        "Please use `DataprocSubmitJobOperator` instead. "
-        "You can use `generate_job` method to generate dictionary representing your job "
-        "and use it with the new operator."
-    ),
+    reason="The DataprocSubmitHadoopJobOperator is deprecated and will be removed after 01.11.2024. "
+    "Please use DataprocSubmitJobOperator class instead. "
+    "You can use `generate_job` method to generate dictionary representing your job "
+    "and use it with the new operator.",
     category=AirflowProviderDeprecationWarning,
 )
 class DataprocSubmitHadoopJobOperator(DataprocJobBaseOperator):
@@ -2001,11 +1997,10 @@ class DataprocSubmitHadoopJobOperator(DataprocJobBaseOperator):
 
 # TODO: Remove one day
 @deprecated(
-    reason=(
-        "Please use `DataprocSubmitJobOperator` instead. "
-        "You can use `generate_job` method to generate dictionary representing your job "
-        "and use it with the new operator."
-    ),
+    reason="The DataprocSubmitPySparkJobOperator is deprecated and will be removed after 01.11.2024. "
+    "Please use DataprocSubmitJobOperator class instead. "
+    "You can use `generate_job` method to generate dictionary representing your job "
+    "and use it with the new operator.",
     category=AirflowProviderDeprecationWarning,
 )
 class DataprocSubmitPySparkJobOperator(DataprocJobBaseOperator):

--- a/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -725,7 +725,8 @@ class GKEStartPodOperator(KubernetesPodOperator):
 
     @staticmethod
     @deprecated(
-        reason="Please use `fetch_cluster_info` instead to get the cluster info for connecting to it.",
+        reason="The get_gke_config_file method is deprecated and will be removed after 01.11.2024. "
+        "Please use `fetch_cluster_info` instead to get the cluster info for connecting to it.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_gke_config_file():

--- a/airflow/providers/google/cloud/operators/life_sciences.py
+++ b/airflow/providers/google/cloud/operators/life_sciences.py
@@ -34,11 +34,10 @@ if TYPE_CHECKING:
 
 
 @deprecated(
-    reason=(
-        "Consider using Google Cloud Batch Operators instead."
-        "The Life Sciences API (beta) will be discontinued "
-        "on July 8, 2025 in favor of Google Cloud Batch."
-    ),
+    reason="The LifeSciencesRunPipelineOperator class is deprecated and will be removed after 08.07.2025. "
+    "Please use Google Cloud Batch Operators instead. "
+    "The Life Sciences API (beta) will be discontinued "
+    "on July 8, 2025 in favor of Google Cloud Batch.",
     category=AirflowProviderDeprecationWarning,
 )
 class LifeSciencesRunPipelineOperator(GoogleCloudBaseOperator):

--- a/airflow/providers/google/cloud/operators/mlengine.py
+++ b/airflow/providers/google/cloud/operators/mlengine.py
@@ -80,11 +80,9 @@ def _normalize_mlengine_job_id(job_id: str) -> str:
 
 
 @deprecated(
-    reason=(
-        "This operator is deprecated. All the functionality of legacy "
-        "MLEngine and new features are available on the Vertex AI platform. "
-        "Please use `CreateBatchPredictionJobOperator`"
-    ),
+    reason="The MLEngineStartBatchPredictionJobOperator is deprecated and will be removed after 01.03.2025. "
+    "Please use CreateBatchPredictionJobOperator class instead."
+    "All the functionality of legacy MLEngine and new features are available on the Vertex AI platform.",
     category=AirflowProviderDeprecationWarning,
 )
 class MLEngineStartBatchPredictionJobOperator(GoogleCloudBaseOperator):
@@ -297,10 +295,9 @@ class MLEngineStartBatchPredictionJobOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason=(
-        "This operator is deprecated. Consider using operators for specific operations: "
-        "MLEngineCreateModelOperator, MLEngineGetModelOperator."
-    ),
+    reason="The MLEngineManageModelOperator is deprecated and will be removed after 01.03.2025. "
+    "Please use one of the following operators for specific operations: "
+    "MLEngineCreateModelOperator, MLEngineGetModelOperator.",
     category=AirflowProviderDeprecationWarning,
 )
 class MLEngineManageModelOperator(GoogleCloudBaseOperator):
@@ -372,11 +369,9 @@ class MLEngineManageModelOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason=(
-        "This operator is deprecated. All the functionality of legacy "
-        "MLEngine and new features are available on the Vertex AI platform. "
-        "Please use appropriate VertexAI operator."
-    ),
+    reason="The MLEngineCreateModelOperator is deprecated and will be removed after 01.11.2025. "
+    "Please use appropriate VertexAI operator instead. "
+    "All the functionality of legacy MLEngine and new features are available on the Vertex AI platform.",
     category=AirflowProviderDeprecationWarning,
 )
 class MLEngineCreateModelOperator(GoogleCloudBaseOperator):
@@ -448,11 +443,9 @@ class MLEngineCreateModelOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason=(
-        "This operator is deprecated. All the functionality of legacy "
-        "MLEngine and new features are available on the Vertex AI platform. "
-        "Please use `GetModelOperator`"
-    ),
+    reason="The MLEngineGetModelOperator is deprecated and will be removed after 01.03.2025. "
+    "Please use GetModelOperator class instead. "
+    "All the functionality of legacy MLEngine and new features are available on the Vertex AI platform.",
     category=AirflowProviderDeprecationWarning,
 )
 class MLEngineGetModelOperator(GoogleCloudBaseOperator):
@@ -523,11 +516,9 @@ class MLEngineGetModelOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason=(
-        "This operator is deprecated. All the functionality of legacy "
-        "MLEngine and new features are available on the Vertex AI platform. "
-        "Please use `DeleteModelOperator`"
-    ),
+    reason="The MLEngineDeleteModelOperator is deprecated and will be removed after 01.03.2025. "
+    "Please use DeleteModelOperator class instead. "
+    "All the functionality of legacy MLEngine and new features are available on the Vertex AI platform.",
     category=AirflowProviderDeprecationWarning,
 )
 class MLEngineDeleteModelOperator(GoogleCloudBaseOperator):
@@ -606,11 +597,9 @@ class MLEngineDeleteModelOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason=(
-        "This operator is deprecated. Consider using operators for specific operations: "
-        "MLEngineCreateVersion, MLEngineSetDefaultVersion, "
-        "MLEngineListVersions, MLEngineDeleteVersion."
-    ),
+    reason="The MLEngineManageVersionOperator is deprecated and will be removed after 01.03.2025. "
+    "Please use the following operators instead: "
+    "MLEngineCreateVersion, MLEngineSetDefaultVersion, MLEngineListVersions, MLEngineDeleteVersion.",
     category=AirflowProviderDeprecationWarning,
 )
 class MLEngineManageVersionOperator(GoogleCloudBaseOperator):
@@ -725,11 +714,9 @@ class MLEngineManageVersionOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason=(
-        "This operator is deprecated. All the functionality of legacy "
-        "MLEngine and new features are available on the Vertex AI platform. "
-        "Please use parent_model parameter for VertexAI operators instead."
-    ),
+    reason="The MLEngineCreateVersionOperator is deprecated and will be removed after 01.03.2025. "
+    "Please use parent_model parameter for VertexAI operators instead. "
+    "All the functionality of legacy MLEngine and new features are available on the Vertex AI platform.",
     category=AirflowProviderDeprecationWarning,
 )
 class MLEngineCreateVersionOperator(GoogleCloudBaseOperator):
@@ -816,11 +803,9 @@ class MLEngineCreateVersionOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason=(
-        "This operator is deprecated. All the functionality of legacy "
-        "MLEngine and new features are available on the Vertex AI platform. "
-        "Please use `SetDefaultVersionOnModelOperator`"
-    ),
+    reason="The MLEngineSetDefaultVersionOperator is deprecated and will be removed after 01.03.2025. "
+    "Please use SetDefaultVersionOnModelOperator class instead. "
+    "All the functionality of legacy MLEngine and new features are available on the Vertex AI platform.",
     category=AirflowProviderDeprecationWarning,
 )
 class MLEngineSetDefaultVersionOperator(GoogleCloudBaseOperator):
@@ -909,11 +894,9 @@ class MLEngineSetDefaultVersionOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason=(
-        "This operator is deprecated. All the functionality of legacy "
-        "MLEngine and new features are available on the Vertex AI platform. "
-        "Please use `ListModelVersionsOperator`"
-    ),
+    reason="The MLEngineListVersionsOperator is deprecated and will be removed after 01.03.2025. "
+    "Please use ListModelVersionsOperator class instead. "
+    "All the functionality of legacy MLEngine and new features are available on the Vertex AI platform.",
     category=AirflowProviderDeprecationWarning,
 )
 class MLEngineListVersionsOperator(GoogleCloudBaseOperator):
@@ -995,11 +978,9 @@ class MLEngineListVersionsOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason=(
-        "This operator is deprecated. All the functionality of legacy "
-        "MLEngine and new features are available on the Vertex AI platform. "
-        "Please use `DeleteModelVersionOperator`"
-    ),
+    reason="The MLEngineDeleteVersionOperator is deprecated and will be removed after 01.03.2025. "
+    "Please use DeleteModelVersionOperator class instead. "
+    "All the functionality of legacy MLEngine and new features are available on the Vertex AI platform.",
     category=AirflowProviderDeprecationWarning,
 )
 class MLEngineDeleteVersionOperator(GoogleCloudBaseOperator):
@@ -1087,11 +1068,9 @@ class MLEngineDeleteVersionOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason=(
-        "This operator is deprecated. All the functionality of legacy "
-        "MLEngine and new features are available on the Vertex AI platform. "
-        "Please use `CreateCustomPythonPackageTrainingJobOperator`"
-    ),
+    reason="The MLEngineStartTrainingJobOperator is deprecated and will be removed after 01.03.2025. "
+    "Please use CreateCustomPythonPackageTrainingJobOperator class instead. "
+    "All the functionality of legacy MLEngine and new features are available on the Vertex AI platform.",
     category=AirflowProviderDeprecationWarning,
 )
 class MLEngineStartTrainingJobOperator(GoogleCloudBaseOperator):
@@ -1426,11 +1405,9 @@ class MLEngineStartTrainingJobOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason=(
-        "This operator is deprecated. All the functionality of legacy "
-        "MLEngine and new features are available on the Vertex AI platform. "
-        "Please use `CancelCustomTrainingJobOperator`"
-    ),
+    reason="The MLEngineTrainingCancelJobOperator is deprecated and will be removed after 01.03.2025. "
+    "Please use CancelCustomTrainingJobOperator class instead. "
+    "All the functionality of legacy MLEngine and new features are available on the Vertex AI platform.",
     category=AirflowProviderDeprecationWarning,
 )
 class MLEngineTrainingCancelJobOperator(GoogleCloudBaseOperator):
@@ -1481,8 +1458,8 @@ class MLEngineTrainingCancelJobOperator(GoogleCloudBaseOperator):
 
     @property
     @deprecated(
-        reason="`_project_id` is deprecated and will be removed in the future. Please use `project_id`"
-        " instead.",
+        reason="The _project_id method is deprecated and will be removed after 01.03.2025. "
+        "Please use project_id method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def _project_id(self):
@@ -1491,7 +1468,8 @@ class MLEngineTrainingCancelJobOperator(GoogleCloudBaseOperator):
 
     @property
     @deprecated(
-        reason="`_job_id` is deprecated and will be removed in the future. Please use `job_id` instead.",
+        reason="The _job_id method is deprecated and will be removed after 01.03.2025. "
+        "Please use job_id method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def _job_id(self):
@@ -1500,8 +1478,8 @@ class MLEngineTrainingCancelJobOperator(GoogleCloudBaseOperator):
 
     @property
     @deprecated(
-        reason="`_impersonation_chain` is deprecated and will be removed in the future."
-        " Please use `impersonation_chain` instead.",
+        reason="The _impersonation_chain method is deprecated and will be removed after 01.03.2025. "
+        "Please use impersonation_chain method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def _impersonation_chain(self):

--- a/airflow/providers/google/cloud/operators/vertex_ai/auto_ml.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/auto_ml.py
@@ -642,8 +642,8 @@ class DeleteAutoMLTrainingJobOperator(GoogleCloudBaseOperator):
 
     @property
     @deprecated(
-        reason="`training_pipeline` is deprecated and will be removed in the future. "
-        "Please use `training_pipeline_id` instead.",
+        reason="The training_pipeline method is deprecated and will be removed after 01.03.2025. "
+        "Please use training_pipeline_id instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def training_pipeline(self):

--- a/airflow/providers/google/cloud/operators/vertex_ai/custom_job.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/custom_job.py
@@ -1633,8 +1633,8 @@ class DeleteCustomTrainingJobOperator(GoogleCloudBaseOperator):
 
     @property
     @deprecated(
-        reason="`training_pipeline` is deprecated and will be removed in the future. "
-        "Please use `training_pipeline_id` instead.",
+        reason="The training_pipeline method is deprecated and will be removed after 01.03.2025. "
+        "Please use training_pipeline_id method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def training_pipeline(self):
@@ -1643,8 +1643,8 @@ class DeleteCustomTrainingJobOperator(GoogleCloudBaseOperator):
 
     @property
     @deprecated(
-        reason="`custom_job` is deprecated and will be removed in the future. "
-        "Please use `custom_job_id` instead.",
+        reason="The custom_job method is deprecated and will be removed after 01.03.2025. "
+        "Please use custom_job_id method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def custom_job(self):

--- a/airflow/providers/google/cloud/operators/vertex_ai/generative_model.py
+++ b/airflow/providers/google/cloud/operators/vertex_ai/generative_model.py
@@ -32,7 +32,8 @@ if TYPE_CHECKING:
 
 
 @deprecated(
-    reason="This operator is deprecated and will be removed after 01.01.2025, please use `TextGenerationModelPredictOperator`.",
+    reason="The PromptLanguageModelOperator is deprecated and will be removed after 01.01.2025. "
+    "Please use TextGenerationModelPredictOperator instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class PromptLanguageModelOperator(GoogleCloudBaseOperator):
@@ -121,7 +122,8 @@ class PromptLanguageModelOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason="This operator is deprecated and will be removed after 01.01.2025, please use `TextEmbeddingModelGetEmbeddingsOperator`.",
+    reason="The GenerateTextEmbeddingsOperator is deprecated and will be removed after 01.01.2025. "
+    "Please use TextEmbeddingModelGetEmbeddingsOperator instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class GenerateTextEmbeddingsOperator(GoogleCloudBaseOperator):
@@ -189,7 +191,8 @@ class GenerateTextEmbeddingsOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason="This operator is deprecated and will be removed after 01.01.2025, please use `GenerativeModelGenerateContentOperator`.",
+    reason="The PromptMultimodalModelOperator is deprecated and will be removed after 01.01.2025. "
+    "Please use GenerativeModelGenerateContentOperator instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class PromptMultimodalModelOperator(GoogleCloudBaseOperator):
@@ -265,7 +268,8 @@ class PromptMultimodalModelOperator(GoogleCloudBaseOperator):
 
 
 @deprecated(
-    reason="This operator is deprecated and will be removed after 01.01.2025, please use `GenerativeModelGenerateContentOperator`.",
+    reason="The PromptMultimodalModelWithMediaOperator is deprecated and will be removed after 01.01.2025. "
+    "Please use GenerativeModelGenerateContentOperator instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class PromptMultimodalModelWithMediaOperator(GoogleCloudBaseOperator):

--- a/airflow/providers/google/cloud/secrets/secret_manager.py
+++ b/airflow/providers/google/cloud/secrets/secret_manager.py
@@ -162,10 +162,8 @@ class CloudSecretManagerBackend(BaseSecretsBackend, LoggingMixin):
         return self._get_secret(self.connections_prefix, conn_id)
 
     @deprecated(
-        reason=(
-            "Method `CloudSecretManagerBackend.get_conn_uri` is deprecated and will be removed "
-            "in a future release.  Please use method `get_conn_value` instead."
-        ),
+        reason="The method get_conn_uri is deprecated and will be removed after 01.11.2024. "
+        "Please use get_conn_value method instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def get_conn_uri(self, conn_id: str) -> str | None:

--- a/airflow/providers/google/cloud/sensors/bigquery.py
+++ b/airflow/providers/google/cloud/sensors/bigquery.py
@@ -273,12 +273,8 @@ class BigQueryTablePartitionExistenceSensor(BaseSensorOperator):
 
 
 @deprecated(
-    reason=(
-        "Class `BigQueryTableExistenceAsyncSensor` is deprecated and "
-        "will be removed in a future release. "
-        "Please use `BigQueryTableExistenceSensor` and "
-        "set `deferrable` attribute to `True` instead"
-    ),
+    reason="The BigQueryTableExistenceAsyncSensor is deprecated and will be removed after 01.11.2024. "
+    "Please use BigQueryTableExistenceSensor and set deferrable attribute to True instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class BigQueryTableExistenceAsyncSensor(BigQueryTableExistenceSensor):
@@ -315,12 +311,9 @@ class BigQueryTableExistenceAsyncSensor(BigQueryTableExistenceSensor):
 
 
 @deprecated(
-    reason=(
-        "Class `BigQueryTableExistencePartitionAsyncSensor` is deprecated and "
-        "will be removed in a future release. "
-        "Please use `BigQueryTablePartitionExistenceSensor` and "
-        "set `deferrable` attribute to `True` instead"
-    ),
+    reason="The BigQueryTableExistencePartitionAsyncSensor is deprecated "
+    "and will be removed after 01.11.2024. "
+    "Please use BigQueryTablePartitionExistenceSensor class and set deferrable attribute to True instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class BigQueryTableExistencePartitionAsyncSensor(BigQueryTablePartitionExistenceSensor):

--- a/airflow/providers/google/cloud/sensors/cloud_composer.py
+++ b/airflow/providers/google/cloud/sensors/cloud_composer.py
@@ -44,10 +44,11 @@ if TYPE_CHECKING:
 
 @deprecated(
     reason=(
-        "The `CloudComposerEnvironmentSensor` operator is deprecated. "
-        "You can achieve the same functionality "
-        "by using operators in deferrable or non-deferrable mode, since every operator for Cloud "
-        "Composer will wait for the operation to complete."
+        "The CloudComposerEnvironmentSensor operator is deprecated and will be removed after 01.11.2024. "
+        "Please use CloudComposerCreateEnvironmentOperator, CloudComposerDeleteEnvironmentOperator or "
+        "CloudComposerUpdateEnvironmentOperator in deferrable or non-deferrable mode, "
+        "since since every operator gives user a possibility to wait (asynchronously or synchronously) "
+        "until the Operation is finished."
     ),
     category=AirflowProviderDeprecationWarning,
 )

--- a/airflow/providers/google/cloud/sensors/gcs.py
+++ b/airflow/providers/google/cloud/sensors/gcs.py
@@ -146,10 +146,8 @@ class GCSObjectExistenceSensor(BaseSensorOperator):
 
 
 @deprecated(
-    reason=(
-        "Class `GCSObjectExistenceAsyncSensor` is deprecated and will be removed in a future release. "
-        "Please use `GCSObjectExistenceSensor` and set `deferrable` attribute to `True` instead"
-    ),
+    reason="The GCSObjectExistenceAsyncSensor is deprecated and will be removed after 01.11.2024. "
+    "Please use GCSObjectExistenceSensor and set deferrable attribute to True instead.",
     category=AirflowProviderDeprecationWarning,
 )
 class GCSObjectExistenceAsyncSensor(GCSObjectExistenceSensor):

--- a/airflow/providers/google/common/hooks/base_google.py
+++ b/airflow/providers/google/common/hooks/base_google.py
@@ -451,7 +451,8 @@ class GoogleBaseHook(BaseHook):
 
     @property
     @deprecated(
-        reason="Please use `airflow.providers.google.common.consts.CLIENT_INFO`.",
+        reason="The client_info method is deprecated and will be removed after 01.03.2025. "
+        "Please use airflow.providers.google.common.consts.CLIENT_INFO instead.",
         category=AirflowProviderDeprecationWarning,
     )
     def client_info(self) -> ClientInfo:

--- a/airflow/providers/google/marketing_platform/hooks/analytics.py
+++ b/airflow/providers/google/marketing_platform/hooks/analytics.py
@@ -28,7 +28,9 @@ from airflow.providers.google.common.hooks.base_google import GoogleBaseHook
 
 
 @deprecated(
-    reason="The `GoogleAnalyticsHook` class is deprecated, please use `GoogleAnalyticsAdminHook` instead.",
+    reason="The GoogleAnalyticsHook class is deprecated and will be removed after 01.11.2024. "
+    "Please use GoogleAnalyticsAdminHook instead. "
+    "The Google Analytics API v3 has sunset and is no longer available as of July 1, 2024.",
     category=AirflowProviderDeprecationWarning,
 )
 class GoogleAnalyticsHook(GoogleBaseHook):

--- a/airflow/providers/google/marketing_platform/operators/analytics.py
+++ b/airflow/providers/google/marketing_platform/operators/analytics.py
@@ -35,10 +35,9 @@ if TYPE_CHECKING:
 
 
 @deprecated(
-    reason=(
-        "The `GoogleAnalyticsListAccountsOperator` class is deprecated, please use "
-        "`GoogleAnalyticsAdminListAccountsOperator` instead."
-    ),
+    reason="The GoogleAnalyticsListAccountsOperator class is deprecated "
+    "and will be removed after 01.11.2024. Please use GoogleAnalyticsAdminListAccountsOperator instead. "
+    "The Google Analytics API v3 has sunset and is no longer available as of July 1, 2024.",
     category=AirflowProviderDeprecationWarning,
 )
 class GoogleAnalyticsListAccountsOperator(BaseOperator):
@@ -102,10 +101,9 @@ class GoogleAnalyticsListAccountsOperator(BaseOperator):
 
 
 @deprecated(
-    reason=(
-        "The `GoogleAnalyticsGetAdsLinkOperator` class is deprecated, please use "
-        "`GoogleAnalyticsAdminGetGoogleAdsLinkOperator` instead."
-    ),
+    reason="The GoogleAnalyticsGetAdsLinkOperator class is deprecated and will be removed after 01.11.2024. "
+    "Please use GoogleAnalyticsAdminGetGoogleAdsLinkOperator instead. "
+    "The Google Analytics API v3 has sunset and is no longer available as of July 1, 2024.",
     category=AirflowProviderDeprecationWarning,
 )
 class GoogleAnalyticsGetAdsLinkOperator(BaseOperator):
@@ -181,10 +179,10 @@ class GoogleAnalyticsGetAdsLinkOperator(BaseOperator):
 
 
 @deprecated(
-    reason=(
-        "The `GoogleAnalyticsRetrieveAdsLinksListOperator` class is deprecated, please use "
-        "`GoogleAnalyticsAdminListGoogleAdsLinksOperator` instead."
-    ),
+    reason="The GoogleAnalyticsRetrieveAdsLinksListOperator is deprecated "
+    "and will be removed after 01.11.2024. "
+    "Please use GoogleAnalyticsAdminListGoogleAdsLinksOperator` instead. "
+    "The Google Analytics API v3 has sunset and is no longer available as of July 1, 2024.",
     category=AirflowProviderDeprecationWarning,
 )
 class GoogleAnalyticsRetrieveAdsLinksListOperator(BaseOperator):
@@ -255,10 +253,9 @@ class GoogleAnalyticsRetrieveAdsLinksListOperator(BaseOperator):
 
 
 @deprecated(
-    reason=(
-        "The `GoogleAnalyticsDataImportUploadOperator` class is deprecated, please use "
-        "`GoogleAnalyticsAdminCreateDataStreamOperator` instead."
-    ),
+    reason="The GoogleAnalyticsDataImportUploadOperator class is deprecated "
+    "and will be removed after 01.11.2024. Please use GoogleAnalyticsAdminCreateDataStreamOperator instead. "
+    "The Google Analytics API v3 has sunset and is no longer available as of July 1, 2024.",
     category=AirflowProviderDeprecationWarning,
 )
 class GoogleAnalyticsDataImportUploadOperator(BaseOperator):
@@ -362,10 +359,9 @@ class GoogleAnalyticsDataImportUploadOperator(BaseOperator):
 
 
 @deprecated(
-    reason=(
-        "The `GoogleAnalyticsDeletePreviousDataUploadsOperator` class is deprecated, please use "
-        "`GoogleAnalyticsAdminDeleteDataStreamOperator` instead."
-    ),
+    reason="The GoogleAnalyticsDeletePreviousDataUploadsOperator is deprecated "
+    "and will be removed after 01.11.2024. Please use GoogleAnalyticsAdminDeleteDataStreamOperator instead. "
+    "The Google Analytics API v3 has sunset and is no longer available as of July 1, 2024.",
     category=AirflowProviderDeprecationWarning,
 )
 class GoogleAnalyticsDeletePreviousDataUploadsOperator(BaseOperator):

--- a/scripts/ci/pre_commit/check_deprecations.py
+++ b/scripts/ci/pre_commit/check_deprecations.py
@@ -19,9 +19,18 @@
 from __future__ import annotations
 
 import ast
+import re
 import sys
+from datetime import date
 from functools import lru_cache
 from pathlib import Path
+from typing import Any
+
+from dateutil.relativedelta import relativedelta
+from rich.console import Console
+
+console = Console(color_system="standard", width=200)
+
 
 allowed_warnings: dict[str, tuple[str, ...]] = {
     "airflow": (
@@ -40,6 +49,63 @@ compatible_decorators: frozenset[tuple[str, ...]] = frozenset(
         ("deprecated", "classic", "deprecated"),
     ]
 )
+end_of_life_deprecation_warnings: dict[str, tuple[str, ...]] = {
+    "airflow/providers/google/": ("AirflowProviderDeprecationWarning",),
+}
+
+
+def is_file_under_eol_deprecation(file_path: str, warning_class: str) -> bool:
+    for prefix, warnings in end_of_life_deprecation_warnings.items():
+        if file_path.startswith(prefix):
+            return bool(warning_class in warnings)
+    return False
+
+
+def validate_end_of_life_deprecation_warnings(file_path: str, decorator: Any, warning_class: str) -> int:
+    _errors = 0
+    if not is_file_under_eol_deprecation(file_path=file_path, warning_class=warning_class):
+        return 0
+    if category_reason := get_decorator_argument(decorator, "reason"):
+        reason_message: str = str(category_reason.value.value)  # type: ignore[attr-defined]
+        reason_pattern = r"(.+?) is deprecated and will be removed after (\d{2})\.(\d{2})\.(\d{4})\. (?:Please use (.+?) |There is no replacement(.+?))"
+        expected_date = date.today() + relativedelta(months=6)
+        if expected_date.day > 1:
+            _date = date.today() + relativedelta(months=7)
+            expected_date = date(day=1, month=_date.month, year=_date.year)
+        expected_date_str: str = expected_date.strftime("%d.%m.%Y")
+        if match := re.search(reason_pattern, reason_message):
+            groups = match.groups()
+            day, month, year = groups[1], groups[2], groups[3]
+            try:
+                date(day=int(day), month=int(month), year=int(year))
+            except ValueError:
+                _errors += 1
+                console.print(
+                    f"{file_path}:{category_reason.lineno}: "
+                    f"[red]Deprecation message contains invalid date '{day}.{month}.{year}'.[/]\n\n"
+                    f"[green]Expected date in the format DD.MM.YYYY "
+                    f"(recommended: {expected_date_str}).[/]"
+                )
+        else:
+            _errors += 1
+            console.print(
+                f"{file_path}:{category_reason.lineno}: "
+                f"[red]Deprecation message is invalid: {reason_message}[/]\n\n"
+                f"[green]Please update it to one of the following formats "
+                f"(note that the removal date is recommended to be at least 6 months ahead):\n\n"
+                f"- The <class/method> is deprecated and will be removed after {expected_date_str}. "
+                f"Please use <new class/new method> instead .\n"
+                f"- The <class/method> is deprecated and will be removed after {expected_date_str}. "
+                f"There is no replacement.[/]\n"
+            )
+    else:
+        _errors += 1
+        console.print(f"{file_path}: reason attribute in the @deprecated decorator was expected.")
+    return _errors
+
+
+def get_decorator_argument(decorator: ast.Call, argument_name: str) -> ast.keyword | None:
+    return next(filter(lambda k: k and k.arg == argument_name, decorator.keywords), None)  # type: ignore[arg-type]
 
 
 @lru_cache(maxsize=None)
@@ -137,9 +203,7 @@ def check_decorators(mod: ast.Module, file: str, file_group: str) -> int:
                 continue
 
             expected_types, warns_types = allowed_group_warnings(file_group)
-            category_keyword: ast.keyword | None = next(
-                filter(lambda k: k and k.arg == "category", decorator.keywords), None
-            )
+            category_keyword = get_decorator_argument(decorator, "category")
             if category_keyword is None:
                 errors += 1
                 print(
@@ -160,6 +224,9 @@ def check_decorators(mod: ast.Module, file: str, file_group: str) -> int:
                         f"{file}:{category_keyword.lineno}: "
                         f"category={category_value}, but {expected_types}"
                     )
+                errors += validate_end_of_life_deprecation_warnings(
+                    file_path=file, decorator=decorator, warning_class=category_value
+                )
             elif isinstance(category_value_ast, ast.Constant):
                 errors += 1
                 print(


### PR DESCRIPTION
This PR introduces unification for deprecation messages formatting within Google's provider package by following:

1. Updated the pre-commit hook `check-code-deprecations` so it enforces a specific message structure containing the end of life date for the deprecated entity. According to the deprecation policy discussed [here](https://lists.apache.org/thread/d4vvr1z2bcpp1zg4rdv4p6dccrlg17g8), this deadline doesn't enforce removal of the deprecated entity from the source code, it only increases transparency and predictability for users, so they knew how much time do they have for the changes on their side.
2. Another reason for this change is preparation for the cleaning-up process as Google's provider package has collected a lot of old code.
3. These changes work only within an `airflow/providers/google` scope. 
4. The default EOL is at least six months ahead.
5. Some classes and methods have assigned earlier deadlines because they have been deprecated for a very long time already and can be removed earlier or their API is shut down and they are not working already. 