### PR TITLE
Fix TestTranslationLegacyModelPredictLink dataset_id error

### DIFF
--- a/airflow/providers/google/cloud/links/translate.py
+++ b/airflow/providers/google/cloud/links/translate.py
@@ -167,13 +167,14 @@ class TranslationLegacyModelPredictLink(BaseGoogleLink):
         task_instance,
         model_id: str,
         project_id: str,
+        dataset_id: str,
     ):
         task_instance.xcom_push(
             context,
             key=TranslationLegacyModelPredictLink.key,
             value={
                 "location": task_instance.location,
-                "dataset_id": task_instance.model.dataset_id,
+                "dataset_id": dataset_id,
                 "model_id": model_id,
                 "project_id": project_id,
             },

--- a/airflow/providers/google/cloud/operators/automl.py
+++ b/airflow/providers/google/cloud/operators/automl.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import ast
 import warnings
 from functools import cached_property
-from typing import TYPE_CHECKING, Sequence, Tuple
+from typing import TYPE_CHECKING, Sequence, Tuple, cast
 
 from google.api_core.gapic_v1.method import DEFAULT, _MethodDefault
 from google.cloud.automl_v1beta1 import (
@@ -279,17 +279,22 @@ class AutoMLPredictOperator(GoogleCloudBaseOperator):
                 impersonation_chain=self.impersonation_chain,
             )
 
+    @cached_property
+    def model(self) -> Model | None:
+        if self.model_id:
+            hook = cast(CloudAutoMLHook, self.hook)
+            return hook.get_model(
+                model_id=self.model_id,
+                location=self.location,
+                project_id=self.project_id,
+                retry=self.retry,
+                timeout=self.timeout,
+                metadata=self.metadata,
+            )
+        return None
+
     def _check_model_type(self):
-        hook = self.hook
-        model = hook.get_model(
-            model_id=self.model_id,
-            location=self.location,
-            project_id=self.project_id,
-            retry=self.retry,
-            timeout=self.timeout,
-            metadata=self.metadata,
-        )
-        if not hasattr(model, "translation_model_metadata"):
+        if not hasattr(self.model, "translation_model_metadata"):
             raise AirflowException(
                 "AutoMLPredictOperator for text, image, and video prediction has been deprecated. "
                 "Please use endpoint_id param instead of model_id param."
@@ -328,11 +333,13 @@ class AutoMLPredictOperator(GoogleCloudBaseOperator):
             )
 
         project_id = self.project_id or hook.project_id
-        if project_id and self.model_id:
+        dataset_id: str | None = self.model.dataset_id if self.model else None
+        if project_id and self.model_id and dataset_id:
             TranslationLegacyModelPredictLink.persist(
                 context=context,
                 task_instance=self,
                 model_id=self.model_id,
+                dataset_id=dataset_id,
                 project_id=project_id,
             )
         return PredictResponse.to_dict(result)
@@ -425,12 +432,16 @@ class AutoMLBatchPredictOperator(GoogleCloudBaseOperator):
         self.input_config = input_config
         self.output_config = output_config
 
-    def execute(self, context: Context):
-        hook = CloudAutoMLHook(
+    @cached_property
+    def hook(self) -> CloudAutoMLHook:
+        return CloudAutoMLHook(
             gcp_conn_id=self.gcp_conn_id,
             impersonation_chain=self.impersonation_chain,
         )
-        self.model: Model = hook.get_model(
+
+    @cached_property
+    def model(self) -> Model:
+        return self.hook.get_model(
             model_id=self.model_id,
             location=self.location,
             project_id=self.project_id,
@@ -439,6 +450,7 @@ class AutoMLBatchPredictOperator(GoogleCloudBaseOperator):
             metadata=self.metadata,
         )
 
+    def execute(self, context: Context):
         if not hasattr(self.model, "translation_model_metadata"):
             _raise_exception_for_deprecated_operator(
                 self.__class__.__name__,
@@ -450,7 +462,7 @@ class AutoMLBatchPredictOperator(GoogleCloudBaseOperator):
                 ],
             )
         self.log.info("Fetch batch prediction.")
-        operation = hook.batch_predict(
+        operation = self.hook.batch_predict(
             model_id=self.model_id,
             input_config=self.input_config,
             output_config=self.output_config,
@@ -461,16 +473,17 @@ class AutoMLBatchPredictOperator(GoogleCloudBaseOperator):
             timeout=self.timeout,
             metadata=self.metadata,
         )
-        operation_result = hook.wait_for_operation(timeout=self.timeout, operation=operation)
+        operation_result = self.hook.wait_for_operation(timeout=self.timeout, operation=operation)
         result = BatchPredictResult.to_dict(operation_result)
         self.log.info("Batch prediction is ready.")
-        project_id = self.project_id or hook.project_id
+        project_id = self.project_id or self.hook.project_id
         if project_id:
             TranslationLegacyModelPredictLink.persist(
                 context=context,
                 task_instance=self,
                 model_id=self.model_id,
                 project_id=project_id,
+                dataset_id=self.model.dataset_id,
             )
         return result
 

--- a/tests/providers/google/cloud/links/test_translate.py
+++ b/tests/providers/google/cloud/links/test_translate.py
@@ -159,6 +159,12 @@ class TestTranslationLegacyModelPredictLink:
         ti.task.model = Model(dataset_id=DATASET, display_name=MODEL)
         session.add(ti)
         session.commit()
-        link.persist(context={"ti": ti}, task_instance=ti.task, model_id=MODEL, project_id=GCP_PROJECT_ID)
+        link.persist(
+            context={"ti": ti},
+            task_instance=ti.task,
+            model_id=MODEL,
+            project_id=GCP_PROJECT_ID,
+            dataset_id=DATASET,
+        )
         actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
         assert actual_url == expected_url

--- a/tests/providers/google/cloud/operators/test_automl.py
+++ b/tests/providers/google/cloud/operators/test_automl.py
@@ -147,6 +147,7 @@ class TestAutoMLBatchPredictOperator:
         mock_hook.return_value.batch_predict.return_value.result.return_value = BatchPredictResult()
         mock_hook.return_value.extract_object_id = extract_object_id
         mock_hook.return_value.wait_for_operation.return_value = BatchPredictResult()
+        mock_hook.return_value.get_model.return_value = mock.MagicMock(**MODEL)
         mock_context = {"ti": mock.MagicMock()}
         op = AutoMLBatchPredictOperator(
             model_id=MODEL_ID,
@@ -174,6 +175,7 @@ class TestAutoMLBatchPredictOperator:
             task_instance=op,
             model_id=MODEL_ID,
             project_id=GCP_PROJECT_ID,
+            dataset_id=DATASET_ID,
         )
 
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
@@ -241,6 +243,7 @@ class TestAutoMLPredictOperator:
     @mock.patch("airflow.providers.google.cloud.operators.automl.CloudAutoMLHook")
     def test_execute(self, mock_hook, mock_link_persist):
         mock_hook.return_value.predict.return_value = PredictResponse()
+        mock_hook.return_value.get_model.return_value = mock.MagicMock(**MODEL)
         mock_context = {"ti": mock.MagicMock()}
         op = AutoMLPredictOperator(
             model_id=MODEL_ID,
@@ -266,6 +269,7 @@ class TestAutoMLPredictOperator:
             task_instance=op,
             model_id=MODEL_ID,
             project_id=GCP_PROJECT_ID,
+            dataset_id=DATASET_ID,
         )
 
     @pytest.mark.db_test


### PR DESCRIPTION
- Add dataset_id parameter to let TestTranslationLegacyModelPredictLink work with the translation model.

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
