### PR TITLE
Bugfix KubernetesJobOperator.on_kill()

### DIFF
--- a/providers/src/airflow/providers/cncf/kubernetes/operators/job.py
+++ b/providers/src/airflow/providers/cncf/kubernetes/operators/job.py
@@ -273,7 +273,6 @@ class KubernetesJobOperator(KubernetesPodOperator):
             kwargs = {
                 "name": job.metadata.name,
                 "namespace": job.metadata.namespace,
-                "job": self.hook.batch_v1_client.api_client.sanitize_for_serialization(self.job),
             }
             if self.termination_grace_period is not None:
                 kwargs.update(grace_period_seconds=self.termination_grace_period)

--- a/providers/tests/cncf/kubernetes/operators/test_job.py
+++ b/providers/tests/cncf/kubernetes/operators/test_job.py
@@ -686,13 +686,10 @@ class TestKubernetesJobOperator:
 
     @pytest.mark.non_db_test_override
     @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.job_client"))
-    @patch(HOOK_CLASS)
-    def test_on_kill(self, mock_hook, mock_client):
+    def test_on_kill(self, mock_client):
         mock_job = mock.MagicMock()
         mock_job.metadata.name = JOB_NAME
         mock_job.metadata.namespace = JOB_NAMESPACE
-        mock_serialize = mock_hook.return_value.batch_v1_client.api_client.sanitize_for_serialization
-        mock_serialized_job = mock_serialize.return_value
 
         op = KubernetesJobOperator(task_id="test_task_id")
         op.job = mock_job
@@ -701,19 +698,14 @@ class TestKubernetesJobOperator:
         mock_client.delete_namespaced_job.assert_called_once_with(
             name=JOB_NAME,
             namespace=JOB_NAMESPACE,
-            job=mock_serialized_job,
         )
-        mock_serialize.assert_called_once_with(mock_job)
 
     @pytest.mark.non_db_test_override
     @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.job_client"))
-    @patch(HOOK_CLASS)
-    def test_on_kill_termination_grace_period(self, mock_hook, mock_client):
+    def test_on_kill_termination_grace_period(self, mock_client):
         mock_job = mock.MagicMock()
         mock_job.metadata.name = JOB_NAME
         mock_job.metadata.namespace = JOB_NAMESPACE
-        mock_serialize = mock_hook.return_value.batch_v1_client.api_client.sanitize_for_serialization
-        mock_serialized_job = mock_serialize.return_value
         mock_termination_grace_period = mock.MagicMock()
 
         op = KubernetesJobOperator(
@@ -725,10 +717,8 @@ class TestKubernetesJobOperator:
         mock_client.delete_namespaced_job.assert_called_once_with(
             name=JOB_NAME,
             namespace=JOB_NAMESPACE,
-            job=mock_serialized_job,
             grace_period_seconds=mock_termination_grace_period,
         )
-        mock_serialize.assert_called_once_with(mock_job)
 
     @pytest.mark.non_db_test_override
     @patch(JOB_OPERATORS_PATH.format("KubernetesJobOperator.client"))


### PR DESCRIPTION
Bugfix the `KubernetesJobOperator` by removing the "job" parameter from the K8s client method call (`delete_namespaced_job`) as it is not expected by [the API](https://github.com/kubernetes-client/python/blob/v31.0.0/kubernetes/docs/BatchV1Api.md#delete_namespaced_job). Apparently this parameter was added here by mistake.