### PR TITLE
Update API version of Google ADS

### DIFF
--- a/providers/google/src/airflow/providers/google/ads/hooks/ads.py
+++ b/providers/google/src/airflow/providers/google/ads/hooks/ads.py
@@ -33,10 +33,10 @@ from airflow.hooks.base import BaseHook
 from airflow.providers.google.common.hooks.base_google import get_field
 
 if TYPE_CHECKING:
-    from google.ads.googleads.v18.services.services.customer_service import CustomerServiceClient
-    from google.ads.googleads.v18.services.services.google_ads_service import GoogleAdsServiceClient
-    from google.ads.googleads.v18.services.services.google_ads_service.pagers import SearchPager
-    from google.ads.googleads.v18.services.types.google_ads_service import GoogleAdsRow
+    from google.ads.googleads.v19.services.services.customer_service import CustomerServiceClient
+    from google.ads.googleads.v19.services.services.google_ads_service import GoogleAdsServiceClient
+    from google.ads.googleads.v19.services.services.google_ads_service.pagers import SearchPager
+    from google.ads.googleads.v19.services.types.google_ads_service import GoogleAdsRow
 
 
 class GoogleAdsHook(BaseHook):

--- a/providers/google/tests/system/google/ads/example_ads.py
+++ b/providers/google/tests/system/google/ads/example_ads.py
@@ -34,7 +34,7 @@ from system.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 # [START howto_google_ads_env_variables]
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT") or DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
-API_VERSION="v19"
+API_VERSION = "v19"
 
 DAG_ID = "example_google_ads"
 

--- a/providers/google/tests/system/google/ads/example_ads.py
+++ b/providers/google/tests/system/google/ads/example_ads.py
@@ -34,6 +34,7 @@ from system.google import DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
 # [START howto_google_ads_env_variables]
 ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT") or DEFAULT_GCP_SYSTEM_TEST_PROJECT_ID
+API_VERSION="v19"
 
 DAG_ID = "example_google_ads"
 
@@ -93,6 +94,7 @@ with DAG(
         obj=GCS_OBJ_PATH,
         bucket=BUCKET_NAME,
         task_id="run_operator",
+        api_version=API_VERSION,
     )
     # [END howto_google_ads_to_gcs_operator]
 


### PR DESCRIPTION
Update of API version to support v19 of Google ADS

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
