### PR TITLE
Handle multiple pods to prevent ```KubernetesJobOperator``` falls with parallelism opt

### DIFF
--- a/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_job.py
+++ b/providers/cncf/kubernetes/tests/unit/cncf/kubernetes/triggers/test_job.py
@@ -45,7 +45,9 @@ def trigger():
     return KubernetesJobTrigger(
         job_name=JOB_NAME,
         job_namespace=NAMESPACE,
-        pod_name=POD_NAME,
+        pod_names=[
+            POD_NAME,
+        ],
         pod_namespace=NAMESPACE,
         base_container_name=CONTAINER_NAME,
         kubernetes_conn_id=CONN_ID,
@@ -66,7 +68,9 @@ class TestKubernetesJobTrigger:
         assert kwargs_dict == {
             "job_name": JOB_NAME,
             "job_namespace": NAMESPACE,
-            "pod_name": POD_NAME,
+            "pod_names": [
+                POD_NAME,
+            ],
             "pod_namespace": NAMESPACE,
             "base_container_name": CONTAINER_NAME,
             "kubernetes_conn_id": CONN_ID,
@@ -105,7 +109,9 @@ class TestKubernetesJobTrigger:
             {
                 "name": JOB_NAME,
                 "namespace": NAMESPACE,
-                "pod_name": POD_NAME,
+                "pod_names": [
+                    POD_NAME,
+                ],
                 "pod_namespace": NAMESPACE,
                 "status": "success",
                 "message": "Job completed successfully",
@@ -141,7 +147,9 @@ class TestKubernetesJobTrigger:
             {
                 "name": JOB_NAME,
                 "namespace": NAMESPACE,
-                "pod_name": POD_NAME,
+                "pod_names": [
+                    POD_NAME,
+                ],
                 "pod_namespace": NAMESPACE,
                 "status": "error",
                 "message": "Job failed with error: Error",

--- a/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -857,8 +857,8 @@ class GKEStartJobOperator(GKEOperatorMixin, KubernetesJobOperator):
                 ssl_ca_cert=self.ssl_ca_cert,
                 job_name=self.job.metadata.name,  # type: ignore[union-attr]
                 job_namespace=self.job.metadata.namespace,  # type: ignore[union-attr]
-                pod_name=self.pod.metadata.name,  # type: ignore[union-attr]
-                pod_namespace=self.pod.metadata.namespace,  # type: ignore[union-attr]
+                pod_names=[pod.metadata.name for pod in self.pods],  # type: ignore[union-attr]
+                pod_namespace=self.pods[0].metadata.namespace,  # type: ignore[union-attr]
                 base_container_name=self.base_container_name,
                 gcp_conn_id=self.gcp_conn_id,
                 poll_interval=self.job_poll_interval,

--- a/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/kubernetes_engine.py
@@ -260,7 +260,7 @@ class GKEJobTrigger(BaseTrigger):
         ssl_ca_cert: str,
         job_name: str,
         job_namespace: str,
-        pod_name: str,
+        pod_names: Sequence[str],
         pod_namespace: str,
         base_container_name: str,
         gcp_conn_id: str = "google_cloud_default",
@@ -274,7 +274,7 @@ class GKEJobTrigger(BaseTrigger):
         self.ssl_ca_cert = ssl_ca_cert
         self.job_name = job_name
         self.job_namespace = job_namespace
-        self.pod_name = pod_name
+        self.pod_names = pod_names
         self.pod_namespace = pod_namespace
         self.base_container_name = base_container_name
         self.gcp_conn_id = gcp_conn_id
@@ -292,7 +292,7 @@ class GKEJobTrigger(BaseTrigger):
                 "ssl_ca_cert": self.ssl_ca_cert,
                 "job_name": self.job_name,
                 "job_namespace": self.job_namespace,
-                "pod_name": self.pod_name,
+                "pod_names": self.pod_names,
                 "pod_namespace": self.pod_namespace,
                 "base_container_name": self.base_container_name,
                 "gcp_conn_id": self.gcp_conn_id,
@@ -305,8 +305,6 @@ class GKEJobTrigger(BaseTrigger):
 
     async def run(self) -> AsyncIterator[TriggerEvent]:  # type: ignore[override]
         """Get current job status and yield a TriggerEvent."""
-        if self.get_logs or self.do_xcom_push:
-            pod = await self.hook.get_pod(name=self.pod_name, namespace=self.pod_namespace)
         if self.do_xcom_push:
             kubernetes_provider = ProvidersManager().providers["apache-airflow-providers-cncf-kubernetes"]
             kubernetes_provider_name = kubernetes_provider.data["package-name"]
@@ -318,22 +316,26 @@ class GKEJobTrigger(BaseTrigger):
                     f"package {kubernetes_provider_name}=={kubernetes_provider_version} which doesn't "
                     f"support this feature. Please upgrade it to version higher than or equal to {min_version}."
                 )
-            await self.hook.wait_until_container_complete(
-                name=self.pod_name,
-                namespace=self.pod_namespace,
-                container_name=self.base_container_name,
-                poll_interval=self.poll_interval,
-            )
-            self.log.info("Checking if xcom sidecar container is started.")
-            await self.hook.wait_until_container_started(
-                name=self.pod_name,
-                namespace=self.pod_namespace,
-                container_name=PodDefaults.SIDECAR_CONTAINER_NAME,
-                poll_interval=self.poll_interval,
-            )
-            self.log.info("Extracting result from xcom sidecar container.")
-            loop = asyncio.get_running_loop()
-            xcom_result = await loop.run_in_executor(None, self.pod_manager.extract_xcom, pod)
+            xcom_results = []
+            for pod_name in self.pod_names:
+                pod = await self.hook.get_pod(name=pod_name, namespace=self.pod_namespace)
+                await self.hook.wait_until_container_complete(
+                    name=pod_name,
+                    namespace=self.pod_namespace,
+                    container_name=self.base_container_name,
+                    poll_interval=self.poll_interval,
+                )
+                self.log.info("Checking if xcom sidecar container is started.")
+                await self.hook.wait_until_container_started(
+                    name=pod_name,
+                    namespace=self.pod_namespace,
+                    container_name=PodDefaults.SIDECAR_CONTAINER_NAME,
+                    poll_interval=self.poll_interval,
+                )
+                self.log.info("Extracting result from xcom sidecar container.")
+                loop = asyncio.get_running_loop()
+                xcom_result = await loop.run_in_executor(None, self.pod_manager.extract_xcom, pod)
+                xcom_results.append(xcom_result)
         job: V1Job = await self.hook.wait_until_job_complete(
             name=self.job_name, namespace=self.job_namespace, poll_interval=self.poll_interval
         )
@@ -345,12 +347,12 @@ class GKEJobTrigger(BaseTrigger):
             {
                 "name": job.metadata.name,
                 "namespace": job.metadata.namespace,
-                "pod_name": pod.metadata.name if self.get_logs else None,
-                "pod_namespace": pod.metadata.namespace if self.get_logs else None,
+                "pod_names": [pod_name for pod_name in self.pod_names] if self.get_logs else None,
+                "pod_namespace": self.pod_namespace if self.get_logs else None,
                 "status": status,
                 "message": message,
                 "job": job_dict,
-                "xcom_result": xcom_result if self.do_xcom_push else None,
+                "xcom_result": xcom_results if self.do_xcom_push else None,
             }
         )
 

--- a/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
@@ -918,6 +918,9 @@ class TestGKEStartJobOperator:
         mock_pod_metadata.name = K8S_POD_NAME
         mock_pod_metadata.namespace = K8S_NAMESPACE
         self.operator.pod = mock.MagicMock(metadata=mock_pod_metadata)
+        self.operator.pods = [
+            self.operator.pod,
+        ]
 
         mock_job_metadata = mock.MagicMock()
         mock_job_metadata.name = K8S_JOB_NAME
@@ -935,7 +938,69 @@ class TestGKEStartJobOperator:
             ssl_ca_cert=GKE_SSL_CA_CERT,
             job_name=K8S_JOB_NAME,
             job_namespace=K8S_NAMESPACE,
-            pod_name=K8S_POD_NAME,
+            pod_names=[
+                K8S_POD_NAME,
+            ],
+            pod_namespace=K8S_NAMESPACE,
+            base_container_name="base",
+            gcp_conn_id=TEST_CONN_ID,
+            poll_interval=10.0,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            get_logs=mock_get_logs,
+            do_xcom_push=False,
+        )
+        mock_defer.assert_called_once_with(
+            trigger=mock_trigger.return_value,
+            method_name="execute_complete",
+        )
+
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEStartJobOperator.defer"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEClusterAuthDetails.fetch_cluster_info"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEHook"))
+    @mock.patch(GKE_OPERATORS_PATH.format("GKEJobTrigger"))
+    def test_execute_deferrable_with_parallelism(
+        self, mock_trigger, mock_cluster_hook, mock_fetch_cluster_info, mock_defer
+    ):
+        op = GKEStartJobOperator(
+            project_id=TEST_PROJECT_ID,
+            location=TEST_LOCATION,
+            cluster_name=GKE_CLUSTER_NAME,
+            task_id=TEST_TASK_ID,
+            name=K8S_JOB_NAME,
+            namespace=K8S_NAMESPACE,
+            image=TEST_IMAGE,
+            gcp_conn_id=TEST_CONN_ID,
+            impersonation_chain=TEST_IMPERSONATION_CHAIN,
+            parallelism=2,
+        )
+        mock_pod_name_1 = K8S_POD_NAME + "-1"
+        mock_pod_metadata_1 = mock.MagicMock()
+        mock_pod_metadata_1.name = mock_pod_name_1
+        mock_pod_metadata_1.namespace = K8S_NAMESPACE
+
+        mock_pod_name_2 = K8S_POD_NAME + "-2"
+        mock_pod_metadata_2 = mock.MagicMock()
+        mock_pod_metadata_2.name = mock_pod_name_2
+        mock_pod_metadata_2.namespace = K8S_NAMESPACE
+        op.pods = [mock.MagicMock(metadata=mock_pod_metadata_1), mock.MagicMock(metadata=mock_pod_metadata_2)]
+
+        mock_job_metadata = mock.MagicMock()
+        mock_job_metadata.name = K8S_JOB_NAME
+        mock_job_metadata.namespace = K8S_NAMESPACE
+        op.job = mock.MagicMock(metadata=mock_job_metadata)
+
+        mock_fetch_cluster_info.return_value = GKE_CLUSTER_URL, GKE_SSL_CA_CERT
+        mock_get_logs = mock.MagicMock()
+        op.get_logs = mock_get_logs
+
+        op.execute_deferrable()
+
+        mock_trigger.assert_called_once_with(
+            cluster_url=GKE_CLUSTER_URL,
+            ssl_ca_cert=GKE_SSL_CA_CERT,
+            job_name=K8S_JOB_NAME,
+            job_namespace=K8S_NAMESPACE,
+            pod_names=[mock_pod_name_1, mock_pod_name_2],
             pod_namespace=K8S_NAMESPACE,
             base_container_name="base",
             gcp_conn_id=TEST_CONN_ID,

--- a/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_kubernetes_engine.py
@@ -98,7 +98,9 @@ def job_trigger():
         ssl_ca_cert=SSL_CA_CERT,
         job_name=JOB_NAME,
         job_namespace=NAMESPACE,
-        pod_name=POD_NAME,
+        pod_names=[
+            POD_NAME,
+        ],
         pod_namespace=NAMESPACE,
         base_container_name=BASE_CONTAINER_NAME,
         gcp_conn_id=GCP_CONN_ID,
@@ -483,7 +485,9 @@ class TestGKEStartJobTrigger:
             "ssl_ca_cert": SSL_CA_CERT,
             "job_name": JOB_NAME,
             "job_namespace": NAMESPACE,
-            "pod_name": POD_NAME,
+            "pod_names": [
+                POD_NAME,
+            ],
             "pod_namespace": NAMESPACE,
             "base_container_name": BASE_CONTAINER_NAME,
             "gcp_conn_id": GCP_CONN_ID,
@@ -522,7 +526,9 @@ class TestGKEStartJobTrigger:
             {
                 "name": JOB_NAME,
                 "namespace": NAMESPACE,
-                "pod_name": POD_NAME,
+                "pod_names": [
+                    POD_NAME,
+                ],
                 "pod_namespace": NAMESPACE,
                 "status": "success",
                 "message": "Job completed successfully",
@@ -560,7 +566,9 @@ class TestGKEStartJobTrigger:
             {
                 "name": JOB_NAME,
                 "namespace": NAMESPACE,
-                "pod_name": POD_NAME,
+                "pod_names": [
+                    POD_NAME,
+                ],
                 "pod_namespace": NAMESPACE,
                 "status": "error",
                 "message": "Job failed with error: Error",


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->
The problem with failing KubernetesJobOperator when using the parallelism option starts to appear from version 8.4.1, according to https://github.com/apache/airflow/issues/44994.

Reason: As ```KubernetesJobOperator``` inherits from ```KubernetesPodOperator```, it also uses some of the parent methods. One of these, ```get_or_create_pod```, is set to find only one or no pod during execution. In case the method finds two pods, it raises the exception 'More than one pod found'. While this is appropriate for the ```KubernetesPodOperator``` logic, ```KubernetesJobOperator``` could use more than one pod during execution. That's why in this PR I introduced a new method, ```get_pods```, which will be more suitable for the logic of this operator. Also, a new attribute, ```self.pods```, has been introduced in the operator. This attribute is needed for handling the logic of the ```do_xcom_push``` and ```get_logs``` flags. 
Change ```KubernetesJobTrigger``` to handle ```KubernetesJobOperator``` with parallelism and ```deferrable``` flag. 
Change ```GKEStartJobOperator.execute_deferrable``` to handle multiple pods.
Change ```GKEJobTrigger``` to handle multiple pods.
Adjust system test ```example_kubernetes_engine_job.py``` in google provider to reflect changes. 
Adjust and add unit tests in providers: cncf/kubernetes, google
<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
