### PR TITLE
Fix ValueError in operators in Google provider

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/links/base.py
+++ b/providers/google/src/airflow/providers/google/cloud/links/base.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, ClassVar
+from urllib.parse import urlparse
 
 from airflow.providers.google.version_compat import (
     AIRFLOW_V_3_0_PLUS,
@@ -108,6 +109,14 @@ class BaseGoogleLink(BaseOperatorLink):
     ) -> str:
         if TYPE_CHECKING:
             assert isinstance(operator, (GoogleCloudBaseOperator, BaseSensorOperator))
+
+        # In cases when worker passes execution to trigger, the value that is put to XCom
+        # already contains link to the object in string format. In this case we don't want to execute
+        # get_config() again. Instead we can leave this value without any changes
+        link_value = XCom.get_value(key=self.key, ti_key=ti_key)
+        if link_value and isinstance(link_value, str):
+            if urlparse(link_value).scheme in ("http", "https"):
+                return link_value
 
         conf = self.get_config(operator, ti_key)
         if not conf:

--- a/providers/google/tests/unit/google/cloud/links/test_base_link.py
+++ b/providers/google/tests/unit/google/cloud/links/test_base_link.py
@@ -29,6 +29,9 @@ from tests_common.test_utils.version_compat import AIRFLOW_V_3_0_PLUS
 
 if AIRFLOW_V_3_0_PLUS:
     from airflow.sdk.execution_time.comms import XComResult
+    from airflow.sdk.execution_time.xcom import XCom
+else:
+    from airflow.models.xcom import XCom  # type: ignore[no-redef]
 
 TEST_LOCATION = "test-location"
 TEST_CLUSTER_ID = "test-cluster-id"
@@ -128,3 +131,73 @@ class TestOperatorWithBaseGoogleLink:
             )
         actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
         assert actual_url == expected_url
+
+    @pytest.mark.db_test
+    @mock.patch.object(XCom, "get_value")
+    def test_get_link_uses_xcom_url_and_skips_get_config(
+        self,
+        mock_get_value,
+        create_task_instance_of_operator,
+        session,
+    ):
+        xcom_url = "https://console.cloud.google.com/some/service?project=test-proj"
+        mock_get_value.return_value = xcom_url
+
+        link = GoogleLink()
+        ti = create_task_instance_of_operator(
+            MyOperator,
+            dag_id="test_link_dag",
+            task_id="test_link_task",
+            location=TEST_LOCATION,
+            cluster_id=TEST_CLUSTER_ID,
+            project_id=TEST_PROJECT_ID,
+        )
+        session.add(ti)
+        session.commit()
+
+        with mock.patch.object(GoogleLink, "get_config", autospec=True) as m_get_config:
+            actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+
+        assert actual_url == xcom_url
+        m_get_config.assert_not_called()
+
+    @pytest.mark.db_test
+    @mock.patch.object(XCom, "get_value")
+    def test_get_link_falls_back_to_get_config_when_xcom_not_http(
+        self,
+        mock_get_value,
+        create_task_instance_of_operator,
+        session,
+    ):
+        mock_get_value.return_value = "gs://bucket/path"
+
+        link = GoogleLink()
+        ti = create_task_instance_of_operator(
+            MyOperator,
+            dag_id="test_link_dag",
+            task_id="test_link_task",
+            location=TEST_LOCATION,
+            cluster_id=TEST_CLUSTER_ID,
+            project_id=TEST_PROJECT_ID,
+        )
+        session.add(ti)
+        session.commit()
+
+        expected_formatted = "https://console.cloud.google.com/expected/link?project=test-proj"
+        with (
+            mock.patch.object(
+                GoogleLink,
+                "get_config",
+                return_value={
+                    "project_id": ti.task.project_id,
+                    "location": ti.task.location,
+                    "cluster_id": ti.task.cluster_id,
+                },
+            ) as m_get_config,
+            mock.patch.object(GoogleLink, "_format_link", return_value=expected_formatted) as m_fmt,
+        ):
+            actual_url = link.get_link(operator=ti.task, ti_key=ti.key)
+
+        assert actual_url == expected_formatted
+        m_get_config.assert_called_once()
+        m_fmt.assert_called_once()


### PR DESCRIPTION
Because of specifics of Airflow3 link implementation, in some cases when the worker passes execution to triggerer, get_link() method is called and the value that is put to XCom already contains link to the object in string format. In this case string can't be iterated as dict, so ValueError is raised.
This PR fixes this error + some small fixes of the link in Dataproc operator.
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
