### PR TITLE
remove the 'provide_authorized_glcoud' from BeamRunPipeline operators

### DIFF
--- a/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
+++ b/providers/apache/beam/src/airflow/providers/apache/beam/operators/beam.py
@@ -441,17 +441,17 @@ class BeamRunPythonPipelineOperator(BeamBasePipelineOperator):
         """Execute the Apache Beam Pipeline on Dataflow runner."""
         if not self.dataflow_hook:
             self.dataflow_hook = self.__set_dataflow_hook()
-        with self.dataflow_hook.provide_authorized_gcloud():
-            self.beam_hook.start_python_pipeline(
-                variables=self.snake_case_pipeline_options,
-                py_file=self.py_file,
-                py_options=self.py_options,
-                py_interpreter=self.py_interpreter,
-                py_requirements=self.py_requirements,
-                py_system_site_packages=self.py_system_site_packages,
-                process_line_callback=self.process_line_callback,
-                is_dataflow_job_id_exist_callback=self.is_dataflow_job_id_exist_callback,
-            )
+
+        self.beam_hook.start_python_pipeline(
+            variables=self.snake_case_pipeline_options,
+            py_file=self.py_file,
+            py_options=self.py_options,
+            py_interpreter=self.py_interpreter,
+            py_requirements=self.py_requirements,
+            py_system_site_packages=self.py_system_site_packages,
+            process_line_callback=self.process_line_callback,
+            is_dataflow_job_id_exist_callback=self.is_dataflow_job_id_exist_callback,
+        )
 
         location = self.dataflow_config.location or DEFAULT_DATAFLOW_LOCATION
         DataflowJobLink.persist(context=context, region=location)
@@ -623,14 +623,13 @@ class BeamRunJavaPipelineOperator(BeamBasePipelineOperator):
 
         if not is_running:
             self.pipeline_options["jobName"] = self.dataflow_job_name
-            with self.dataflow_hook.provide_authorized_gcloud():
-                self.beam_hook.start_java_pipeline(
-                    variables=self.pipeline_options,
-                    jar=self.jar,
-                    job_class=self.job_class,
-                    process_line_callback=self.process_line_callback,
-                    is_dataflow_job_id_exist_callback=self.is_dataflow_job_id_exist_callback,
-                )
+            self.beam_hook.start_java_pipeline(
+                variables=self.pipeline_options,
+                jar=self.jar,
+                job_class=self.job_class,
+                process_line_callback=self.process_line_callback,
+                is_dataflow_job_id_exist_callback=self.is_dataflow_job_id_exist_callback,
+            )
             if self.dataflow_job_name and self.dataflow_config.location:
                 DataflowJobLink.persist(context=context)
                 if self.deferrable:
@@ -790,12 +789,11 @@ class BeamRunGoPipelineOperator(BeamBasePipelineOperator):
                 go_artifact.download_from_gcs(gcs_hook=gcs_hook, tmp_dir=tmp_dir)
 
             if is_dataflow and self.dataflow_hook:
-                with self.dataflow_hook.provide_authorized_gcloud():
-                    go_artifact.start_pipeline(
-                        beam_hook=self.beam_hook,
-                        variables=snake_case_pipeline_options,
-                        process_line_callback=process_line_callback,
-                    )
+                go_artifact.start_pipeline(
+                    beam_hook=self.beam_hook,
+                    variables=snake_case_pipeline_options,
+                    process_line_callback=process_line_callback,
+                )
                 DataflowJobLink.persist(context=context)
                 if dataflow_job_name and self.dataflow_config.location:
                     self.dataflow_hook.wait_for_done(

--- a/providers/apache/beam/tests/unit/apache/beam/operators/test_beam.py
+++ b/providers/apache/beam/tests/unit/apache/beam/operators/test_beam.py
@@ -245,7 +245,6 @@ class TestBeamRunPythonPipelineOperator:
             process_line_callback=mock.ANY,
             is_dataflow_job_id_exist_callback=mock.ANY,
         )
-        dataflow_hook_mock.return_value.provide_authorized_gcloud.assert_called_once_with()
 
     @mock.patch(BEAM_OPERATOR_PATH.format("DataflowJobLink.persist"))
     @mock.patch(BEAM_OPERATOR_PATH.format("BeamHook"))
@@ -760,7 +759,6 @@ class TestBeamRunGoPipelineOperator:
             multiple_jobs=False,
             project_id=dataflow_config.project_id,
         )
-        dataflow_hook_mock.return_value.provide_authorized_gcloud.assert_called_once_with()
 
     @mock.patch(BEAM_OPERATOR_PATH.format("DataflowJobLink.persist"))
     @mock.patch(BEAM_OPERATOR_PATH.format("DataflowHook"))
@@ -789,8 +787,6 @@ class TestBeamRunGoPipelineOperator:
         gcs_download_method.side_effect = gcs_download_side_effect
 
         mock_dataflow_hook.build_dataflow_job_name.return_value = "test-job"
-
-        provide_authorized_gcloud_method = mock_dataflow_hook.return_value.provide_authorized_gcloud
         start_go_pipeline_method = mock_beam_hook.return_value.start_go_pipeline_with_binary
         wait_for_done_method = mock_dataflow_hook.return_value.wait_for_done
 
@@ -835,7 +831,6 @@ class TestBeamRunGoPipelineOperator:
             cancel_timeout=dataflow_config.cancel_timeout,
             wait_until_finished=dataflow_config.wait_until_finished,
         )
-        provide_authorized_gcloud_method.assert_called_once_with()
         start_go_pipeline_method.assert_called_once_with(
             variables=expected_options,
             launcher_binary=expected_launcher_binary,
@@ -971,7 +966,6 @@ class TestBeamRunPythonPipelineOperatorAsync:
             wait_until_finished=dataflow_config.wait_until_finished,
         )
         beam_hook_mock.return_value.start_python_pipeline.assert_called_once()
-        dataflow_hook_mock.return_value.provide_authorized_gcloud.assert_called_once_with()
 
     @mock.patch(BEAM_OPERATOR_PATH.format("DataflowJobLink.persist"))
     @mock.patch(BEAM_OPERATOR_PATH.format("BeamHook"))
@@ -1100,7 +1094,6 @@ class TestBeamRunJavaPipelineOperatorAsync:
             wait_until_finished=dataflow_config.wait_until_finished,
         )
         beam_hook_mock.return_value.start_python_pipeline.assert_not_called()
-        dataflow_hook_mock.return_value.provide_authorized_gcloud.assert_called_once_with()
 
     @mock.patch(BEAM_OPERATOR_PATH.format("DataflowJobLink.persist"))
     @mock.patch(BEAM_OPERATOR_PATH.format("BeamHook"))


### PR DESCRIPTION
- As durng the operator execution we launch cmd calling beam tool with the dataflow runner it fully cappable to work with standard google credentals, so no need to set them manually here, more over the authorized gcloud session has no use running beam on dataflow.

- There is known bug (https://github.com/apache/airflow/issues/42396), where calling the provide_authorized_gcloud disrupts the ADC lookup for the beam itself.

closes: https://github.com/apache/airflow/issues/42396

<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
