### PR TITLE
Make Xcom values unified in whole Google provider

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/links/base.py
+++ b/providers/google/src/airflow/providers/google/cloud/links/base.py
@@ -78,7 +78,7 @@ class BaseGoogleLink(BaseOperatorLink):
             if common_params:
                 params.update(common_params)
 
-        context["ti"].xcom_push(
+        context["task_instance"].xcom_push(
             key=cls.key,
             value={
                 **params,

--- a/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
+++ b/providers/google/src/airflow/providers/google/cloud/log/gcs_task_handler.py
@@ -261,7 +261,7 @@ class GCSTaskHandler(FileTaskHandler, LoggingMixin):
         if not self.upload_on_close:
             return
 
-        if hasattr(self, "ti"):
+        if hasattr(self, "task_instance"):
             self.io.upload(self.log_relative_path, self.ti)
 
         # Mark closed so we don't double write if close is called twice

--- a/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigquery.py
@@ -280,7 +280,7 @@ class BigQueryCheckOperator(
             if self.project_id is None:
                 self.project_id = hook.project_id
             job = self._submit_job(hook, job_id="")
-            context["ti"].xcom_push(key="job_id", value=job.job_id)
+            context["task_instance"].xcom_push(key="job_id", value=job.job_id)
             if job.running():
                 self.defer(
                     timeout=self.execution_timeout,
@@ -435,7 +435,7 @@ class BigQueryValueCheckOperator(
             if self.project_id is None:
                 self.project_id = hook.project_id
             job = self._submit_job(hook, job_id="")
-            context["ti"].xcom_push(key="job_id", value=job.job_id)
+            context["task_instance"].xcom_push(key="job_id", value=job.job_id)
             if job.running():
                 self.defer(
                     timeout=self.execution_timeout,
@@ -604,7 +604,7 @@ class BigQueryIntervalCheckOperator(
 
             self.log.info("Executing SQL check: %s", self.sql1)
             job_1 = self._submit_job(hook, sql=self.sql1, job_id="")
-            context["ti"].xcom_push(key="job_id", value=job_1.job_id)
+            context["task_instance"].xcom_push(key="job_id", value=job_1.job_id)
 
             self.log.info("Executing SQL check: %s", self.sql2)
             job_2 = self._submit_job(hook, sql=self.sql2, job_id="")
@@ -751,7 +751,7 @@ class BigQueryColumnCheckOperator(
         failed_tests = []
 
         job = self._submit_job(hook, job_id="")
-        context["ti"].xcom_push(key="job_id", value=job.job_id)
+        context["task_instance"].xcom_push(key="job_id", value=job.job_id)
         records = job.result().to_dataframe()
 
         if records.empty:
@@ -880,7 +880,7 @@ class BigQueryTableCheckOperator(
         if self.project_id is None:
             self.project_id = hook.project_id
         job = self._submit_job(hook, job_id="")
-        context["ti"].xcom_push(key="job_id", value=job.job_id)
+        context["task_instance"].xcom_push(key="job_id", value=job.job_id)
         records = job.result().to_dataframe()
 
         if records.empty:
@@ -1170,7 +1170,7 @@ class BigQueryGetDataOperator(GoogleCloudBaseOperator, _BigQueryOperatorsEncrypt
                 job_id=self.job_id, project_id=self.job_project_id or hook.project_id, location=self.location
             )
 
-        context["ti"].xcom_push(key="job_id", value=job.job_id)
+        context["task_instance"].xcom_push(key="job_id", value=job.job_id)
         self.defer(
             timeout=self.execution_timeout,
             trigger=BigQueryGetDataTrigger(
@@ -2450,7 +2450,7 @@ class BigQueryInsertJobOperator(GoogleCloudBaseOperator, _BigQueryInsertJobOpera
                 project_id=self.project_id,
                 location=self.location,
             )
-            context["ti"].xcom_push(key="job_id_path", value=job_id_path)
+            context["task_instance"].xcom_push(key="job_id_path", value=job_id_path)
 
         persist_kwargs = {
             "context": context,

--- a/providers/google/src/airflow/providers/google/cloud/operators/bigquery_dts.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/bigquery_dts.py
@@ -141,7 +141,7 @@ class BigQueryCreateDataTransferOperator(GoogleCloudBaseOperator):
 
         result = TransferConfig.to_dict(response)
         self.log.info("Created DTS transfer config %s", get_object_id(result))
-        context["ti"].xcom_push(key="transfer_config_id", value=get_object_id(result))
+        context["task_instance"].xcom_push(key="transfer_config_id", value=get_object_id(result))
         # don't push AWS secret in XCOM
         result.get("params", {}).pop("secret_access_key", None)
         result.get("params", {}).pop("access_key_id", None)
@@ -335,7 +335,7 @@ class BigQueryDataTransferServiceStartTransferRunsOperator(GoogleCloudBaseOperat
 
         result = StartManualTransferRunsResponse.to_dict(response)
         run_id = get_object_id(result["runs"][0])
-        context["ti"].xcom_push(key="run_id", value=run_id)
+        context["task_instance"].xcom_push(key="run_id", value=run_id)
 
         if not self.deferrable:
             # Save as attribute for further use by OpenLineage

--- a/providers/google/src/airflow/providers/google/cloud/operators/cloud_composer.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/cloud_composer.py
@@ -160,7 +160,7 @@ class CloudComposerCreateEnvironmentOperator(GoogleCloudBaseOperator):
                 timeout=self.timeout,
                 metadata=self.metadata,
             )
-            context["ti"].xcom_push(key="operation_id", value=result.operation.name)
+            context["task_instance"].xcom_push(key="operation_id", value=result.operation.name)
 
             if not self.deferrable:
                 environment = hook.wait_for_operation(timeout=self.timeout, operation=result)

--- a/providers/google/src/airflow/providers/google/cloud/operators/datacatalog.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/datacatalog.py
@@ -163,7 +163,7 @@ class CloudDataCatalogCreateEntryOperator(GoogleCloudBaseOperator):
             )
         _, _, entry_id = result.name.rpartition("/")
         self.log.info("Current entry_id ID: %s", entry_id)
-        context["ti"].xcom_push(key="entry_id", value=entry_id)
+        context["task_instance"].xcom_push(key="entry_id", value=entry_id)
         DataCatalogEntryLink.persist(
             context=context,
             entry_id=self.entry_id,
@@ -283,7 +283,7 @@ class CloudDataCatalogCreateEntryGroupOperator(GoogleCloudBaseOperator):
 
         _, _, entry_group_id = result.name.rpartition("/")
         self.log.info("Current entry group ID: %s", entry_group_id)
-        context["ti"].xcom_push(key="entry_group_id", value=entry_group_id)
+        context["task_instance"].xcom_push(key="entry_group_id", value=entry_group_id)
         DataCatalogEntryGroupLink.persist(
             context=context,
             entry_group_id=self.entry_group_id,
@@ -425,7 +425,7 @@ class CloudDataCatalogCreateTagOperator(GoogleCloudBaseOperator):
 
         _, _, tag_id = tag.name.rpartition("/")
         self.log.info("Current Tag ID: %s", tag_id)
-        context["ti"].xcom_push(key="tag_id", value=tag_id)
+        context["task_instance"].xcom_push(key="tag_id", value=tag_id)
         DataCatalogEntryLink.persist(
             context=context,
             entry_id=self.entry,
@@ -542,7 +542,7 @@ class CloudDataCatalogCreateTagTemplateOperator(GoogleCloudBaseOperator):
             )
         _, _, tag_template = result.name.rpartition("/")
         self.log.info("Current Tag ID: %s", tag_template)
-        context["ti"].xcom_push(key="tag_template_id", value=tag_template)
+        context["task_instance"].xcom_push(key="tag_template_id", value=tag_template)
         DataCatalogTagTemplateLink.persist(
             context=context,
             tag_template_id=self.tag_template_id,
@@ -668,7 +668,7 @@ class CloudDataCatalogCreateTagTemplateFieldOperator(GoogleCloudBaseOperator):
             result = tag_template.fields[self.tag_template_field_id]
 
         self.log.info("Current Tag ID: %s", self.tag_template_field_id)
-        context["ti"].xcom_push(key="tag_template_field_id", value=self.tag_template_field_id)
+        context["task_instance"].xcom_push(key="tag_template_field_id", value=self.tag_template_field_id)
         DataCatalogTagTemplateLink.persist(
             context=context,
             tag_template_id=self.tag_template,

--- a/providers/google/src/airflow/providers/google/cloud/operators/dataplex.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/dataplex.py
@@ -2533,7 +2533,7 @@ class DataplexCatalogListEntryGroupsOperator(DataplexCatalogBaseOperator):
                 metadata=self.metadata,
             )
             self.log.info("EntryGroup on page: %s", entry_group_on_page)
-            context["ti"].xcom_push(
+            context["task_instance"].xcom_push(
                 key="entry_group_page",
                 value=ListEntryGroupsResponse.to_dict(entry_group_on_page._response),
             )
@@ -2953,7 +2953,7 @@ class DataplexCatalogListEntryTypesOperator(DataplexCatalogBaseOperator):
                 metadata=self.metadata,
             )
             self.log.info("EntryType on page: %s", entry_type_on_page)
-            context["ti"].xcom_push(
+            context["task_instance"].xcom_push(
                 key="entry_type_page",
                 value=ListEntryTypesResponse.to_dict(entry_type_on_page._response),
             )
@@ -3306,7 +3306,7 @@ class DataplexCatalogListAspectTypesOperator(DataplexCatalogBaseOperator):
                 metadata=self.metadata,
             )
             self.log.info("AspectType on page: %s", aspect_type_on_page)
-            context["ti"].xcom_push(
+            context["task_instance"].xcom_push(
                 key="aspect_type_page",
                 value=ListAspectTypesResponse.to_dict(aspect_type_on_page._response),
             )
@@ -3800,7 +3800,7 @@ class DataplexCatalogListEntriesOperator(DataplexCatalogBaseOperator):
                 metadata=self.metadata,
             )
             self.log.info("Entries on page: %s", entries_on_page)
-            context["ti"].xcom_push(
+            context["task_instance"].xcom_push(
                 key="entry_page",
                 value=ListEntriesResponse.to_dict(entries_on_page._response),
             )
@@ -3897,7 +3897,7 @@ class DataplexCatalogSearchEntriesOperator(DataplexCatalogBaseOperator):
                 metadata=self.metadata,
             )
             self.log.info("Entries on page: %s", entries_on_page)
-            context["ti"].xcom_push(
+            context["task_instance"].xcom_push(
                 key="entry_page",
                 value=SearchEntriesResponse.to_dict(entries_on_page._response),
             )

--- a/providers/google/src/airflow/providers/google/cloud/operators/functions.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/functions.py
@@ -488,7 +488,7 @@ class CloudFunctionInvokeFunctionOperator(GoogleCloudBaseOperator):
             project_id=self.project_id,
         )
         self.log.info("Function called successfully. Execution id %s", result.get("executionId"))
-        context["ti"].xcom_push(key="execution_id", value=result.get("executionId"))
+        context["task_instance"].xcom_push(key="execution_id", value=result.get("executionId"))
 
         project_id = self.project_id or hook.project_id
         if project_id:

--- a/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/kubernetes_engine.py
@@ -956,7 +956,7 @@ class GKEListJobsOperator(GKEOperatorMixin, GoogleCloudBaseOperator):
         for job in jobs.items:
             self.log.info("Retrieved description of Job:\n %s", job)
         if self.do_xcom_push:
-            ti = context["ti"]
+            ti = context["task_instance"]
             ti.xcom_push(key="jobs_list", value=V1JobList.to_dict(jobs))
         KubernetesEngineWorkloadsLink.persist(context=context)
         return V1JobList.to_dict(jobs)

--- a/providers/google/src/airflow/providers/google/cloud/operators/managed_kafka.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/managed_kafka.py
@@ -256,7 +256,7 @@ class ManagedKafkaListClustersOperator(ManagedKafkaBaseOperator):
                 timeout=self.timeout,
                 metadata=self.metadata,
             )
-            context["ti"].xcom_push(
+            context["task_instance"].xcom_push(
                 key="cluster_page",
                 value=types.ListClustersResponse.to_dict(cluster_list_pager._response),
             )
@@ -621,7 +621,7 @@ class ManagedKafkaListTopicsOperator(ManagedKafkaBaseOperator):
                 timeout=self.timeout,
                 metadata=self.metadata,
             )
-            context["ti"].xcom_push(
+            context["task_instance"].xcom_push(
                 key="topic_page",
                 value=types.ListTopicsResponse.to_dict(topic_list_pager._response),
             )
@@ -895,7 +895,7 @@ class ManagedKafkaListConsumerGroupsOperator(ManagedKafkaBaseOperator):
                 timeout=self.timeout,
                 metadata=self.metadata,
             )
-            context["ti"].xcom_push(
+            context["task_instance"].xcom_push(
                 key="consumer_group_page",
                 value=types.ListConsumerGroupsResponse.to_dict(consumer_group_list_pager._response),
             )

--- a/providers/google/src/airflow/providers/google/cloud/operators/translate.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/translate.py
@@ -480,7 +480,7 @@ class TranslateCreateDatasetOperator(GoogleCloudBaseOperator):
         result = hook.wait_for_operation_result(result_operation)
         result = type(result).to_dict(result)
         dataset_id = hook.extract_object_id(result)
-        context["ti"].xcom_push(key="dataset_id", value=dataset_id)
+        context["task_instance"].xcom_push(key="dataset_id", value=dataset_id)
         self.log.info("Dataset creation complete. The dataset_id: %s.", dataset_id)
 
         project_id = self.project_id or hook.project_id
@@ -849,7 +849,7 @@ class TranslateCreateModelOperator(GoogleCloudBaseOperator):
         result = hook.wait_for_operation_result(operation=result_operation)
         result = type(result).to_dict(result)
         model_id = hook.extract_object_id(result)
-        context["ti"].xcom_push(key="model_id", value=model_id)
+        context["task_instance"].xcom_push(key="model_id", value=model_id)
         self.log.info("Model creation complete. The model_id: %s.", model_id)
 
         project_id = self.project_id or hook.project_id
@@ -1436,7 +1436,7 @@ class TranslateCreateGlossaryOperator(GoogleCloudBaseOperator):
         result = type(result).to_dict(result)
 
         glossary_id = hook.extract_object_id(result)
-        context["ti"].xcom_push(key="glossary_id", value=glossary_id)
+        context["task_instance"].xcom_push(key="glossary_id", value=glossary_id)
         self.log.info("Glossary creation complete. The glossary_id: %s.", glossary_id)
         return result
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/auto_ml.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/auto_ml.py
@@ -249,11 +249,11 @@ class CreateAutoMLForecastingTrainingJobOperator(AutoMLTrainingJobBaseOperator):
         if model:
             result = Model.to_dict(model)
             model_id = self.hook.extract_model_id(result)
-            context["ti"].xcom_push(key="model_id", value=model_id)
+            context["task_instance"].xcom_push(key="model_id", value=model_id)
             VertexAIModelLink.persist(context=context, model_id=model_id)
         else:
             result = model  # type: ignore
-        context["ti"].xcom_push(key="training_id", value=training_id)
+        context["task_instance"].xcom_push(key="training_id", value=training_id)
         VertexAITrainingLink.persist(context=context, training_id=training_id)
         return result
 
@@ -341,11 +341,11 @@ class CreateAutoMLImageTrainingJobOperator(AutoMLTrainingJobBaseOperator):
         if model:
             result = Model.to_dict(model)
             model_id = self.hook.extract_model_id(result)
-            context["ti"].xcom_push(key="model_id", value=model_id)
+            context["task_instance"].xcom_push(key="model_id", value=model_id)
             VertexAIModelLink.persist(context=context, model_id=model_id)
         else:
             result = model  # type: ignore
-        context["ti"].xcom_push(key="training_id", value=training_id)
+        context["task_instance"].xcom_push(key="training_id", value=training_id)
         VertexAITrainingLink.persist(context=context, training_id=training_id)
         return result
 
@@ -464,11 +464,11 @@ class CreateAutoMLTabularTrainingJobOperator(AutoMLTrainingJobBaseOperator):
         if model:
             result = Model.to_dict(model)
             model_id = self.hook.extract_model_id(result)
-            context["ti"].xcom_push(key="model_id", value=model_id)
+            context["task_instance"].xcom_push(key="model_id", value=model_id)
             VertexAIModelLink.persist(context=context, model_id=model_id)
         else:
             result = model  # type: ignore
-        context["ti"].xcom_push(key="training_id", value=training_id)
+        context["task_instance"].xcom_push(key="training_id", value=training_id)
         VertexAITrainingLink.persist(context=context, training_id=training_id)
         return result
 
@@ -538,11 +538,11 @@ class CreateAutoMLVideoTrainingJobOperator(AutoMLTrainingJobBaseOperator):
         if model:
             result = Model.to_dict(model)
             model_id = self.hook.extract_model_id(result)
-            context["ti"].xcom_push(key="model_id", value=model_id)
+            context["task_instance"].xcom_push(key="model_id", value=model_id)
             VertexAIModelLink.persist(context=context, model_id=model_id)
         else:
             result = model  # type: ignore
-        context["ti"].xcom_push(key="training_id", value=training_id)
+        context["task_instance"].xcom_push(key="training_id", value=training_id)
         VertexAITrainingLink.persist(context=context, training_id=training_id)
         return result
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/batch_prediction_job.py
@@ -269,7 +269,7 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
         batch_prediction_job_id = batch_prediction_job.name
         self.log.info("Batch prediction job was created. Job id: %s", batch_prediction_job_id)
 
-        context["ti"].xcom_push(key="batch_prediction_job_id", value=batch_prediction_job_id)
+        context["task_instance"].xcom_push(key="batch_prediction_job_id", value=batch_prediction_job_id)
         VertexAIBatchPredictionJobLink.persist(
             context=context,
             batch_prediction_job_id=batch_prediction_job_id,
@@ -303,11 +303,11 @@ class CreateBatchPredictionJobOperator(GoogleCloudBaseOperator):
         job: dict[str, Any] = event["job"]
         self.log.info("Batch prediction job %s created and completed successfully.", job["name"])
         job_id = self.hook.extract_batch_prediction_job_id(job)
-        context["ti"].xcom_push(
+        context["task_instance"].xcom_push(
             key="batch_prediction_job_id",
             value=job_id,
         )
-        context["ti"].xcom_push(
+        context["task_instance"].xcom_push(
             key="training_conf",
             value={
                 "training_conf_id": job_id,

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/custom_job.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/custom_job.py
@@ -185,11 +185,11 @@ class CustomTrainingJobBaseOperator(GoogleCloudBaseOperator):
             raise AirflowException(event["message"])
         training_pipeline = event["job"]
         custom_job_id = self.hook.extract_custom_job_id_from_training_pipeline(training_pipeline)
-        context["ti"].xcom_push(key="custom_job_id", value=custom_job_id)
+        context["task_instance"].xcom_push(key="custom_job_id", value=custom_job_id)
         try:
             model = training_pipeline["model_to_upload"]
             model_id = self.hook.extract_model_id(model)
-            context["ti"].xcom_push(key="model_id", value=model_id)
+            context["task_instance"].xcom_push(key="model_id", value=model_id)
             VertexAIModelLink.persist(context=context, model_id=model_id)
             return model
         except KeyError:
@@ -597,12 +597,12 @@ class CreateCustomContainerTrainingJobOperator(CustomTrainingJobBaseOperator):
         if model:
             result = Model.to_dict(model)
             model_id = self.hook.extract_model_id(result)
-            context["ti"].xcom_push(key="model_id", value=model_id)
+            context["task_instance"].xcom_push(key="model_id", value=model_id)
             VertexAIModelLink.persist(context=context, model_id=model_id)
         else:
             result = model  # type: ignore
-        context["ti"].xcom_push(key="training_id", value=training_id)
-        context["ti"].xcom_push(key="custom_job_id", value=custom_job_id)
+        context["task_instance"].xcom_push(key="training_id", value=training_id)
+        context["task_instance"].xcom_push(key="custom_job_id", value=custom_job_id)
         VertexAITrainingLink.persist(context=context, training_id=training_id)
         return result
 
@@ -662,7 +662,7 @@ class CreateCustomContainerTrainingJobOperator(CustomTrainingJobBaseOperator):
         )
         custom_container_training_job_obj.wait_for_resource_creation()
         training_pipeline_id: str = custom_container_training_job_obj.name
-        context["ti"].xcom_push(key="training_id", value=training_pipeline_id)
+        context["task_instance"].xcom_push(key="training_id", value=training_pipeline_id)
         VertexAITrainingLink.persist(context=context, training_id=training_pipeline_id)
         self.defer(
             trigger=CustomContainerTrainingJobTrigger(
@@ -1058,12 +1058,12 @@ class CreateCustomPythonPackageTrainingJobOperator(CustomTrainingJobBaseOperator
         if model:
             result = Model.to_dict(model)
             model_id = self.hook.extract_model_id(result)
-            context["ti"].xcom_push(key="model_id", value=model_id)
+            context["task_instance"].xcom_push(key="model_id", value=model_id)
             VertexAIModelLink.persist(context=context, model_id=model_id)
         else:
             result = model  # type: ignore
-        context["ti"].xcom_push(key="training_id", value=training_id)
-        context["ti"].xcom_push(key="custom_job_id", value=custom_job_id)
+        context["task_instance"].xcom_push(key="training_id", value=training_id)
+        context["task_instance"].xcom_push(key="custom_job_id", value=custom_job_id)
         VertexAITrainingLink.persist(context=context, training_id=training_id)
         return result
 
@@ -1124,7 +1124,7 @@ class CreateCustomPythonPackageTrainingJobOperator(CustomTrainingJobBaseOperator
         )
         custom_python_training_job_obj.wait_for_resource_creation()
         training_pipeline_id: str = custom_python_training_job_obj.name
-        context["ti"].xcom_push(key="training_id", value=training_pipeline_id)
+        context["task_instance"].xcom_push(key="training_id", value=training_pipeline_id)
         VertexAITrainingLink.persist(context=context, training_id=training_pipeline_id)
         self.defer(
             trigger=CustomPythonPackageTrainingJobTrigger(
@@ -1525,12 +1525,12 @@ class CreateCustomTrainingJobOperator(CustomTrainingJobBaseOperator):
         if model:
             result = Model.to_dict(model)
             model_id = self.hook.extract_model_id(result)
-            context["ti"].xcom_push(key="model_id", value=model_id)
+            context["task_instance"].xcom_push(key="model_id", value=model_id)
             VertexAIModelLink.persist(context=context, model_id=model_id)
         else:
             result = model  # type: ignore
-        context["ti"].xcom_push(key="training_id", value=training_id)
-        context["ti"].xcom_push(key="custom_job_id", value=custom_job_id)
+        context["task_instance"].xcom_push(key="training_id", value=training_id)
+        context["task_instance"].xcom_push(key="custom_job_id", value=custom_job_id)
         VertexAITrainingLink.persist(context=context, training_id=training_id)
         return result
 
@@ -1591,7 +1591,7 @@ class CreateCustomTrainingJobOperator(CustomTrainingJobBaseOperator):
         )
         custom_training_job_obj.wait_for_resource_creation()
         training_pipeline_id: str = custom_training_job_obj.name
-        context["ti"].xcom_push(key="training_id", value=training_pipeline_id)
+        context["task_instance"].xcom_push(key="training_id", value=training_pipeline_id)
         VertexAITrainingLink.persist(context=context, training_id=training_pipeline_id)
         self.defer(
             trigger=CustomTrainingJobTrigger(

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/dataset.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/dataset.py
@@ -114,7 +114,7 @@ class CreateDatasetOperator(GoogleCloudBaseOperator):
         dataset_id = hook.extract_dataset_id(dataset)
         self.log.info("Dataset was created. Dataset id: %s", dataset_id)
 
-        context["ti"].xcom_push(key="dataset_id", value=dataset_id)
+        context["task_instance"].xcom_push(key="dataset_id", value=dataset_id)
         VertexAIDatasetLink.persist(context=context, dataset_id=dataset_id)
         return dataset
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/endpoint_service.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/endpoint_service.py
@@ -122,7 +122,7 @@ class CreateEndpointOperator(GoogleCloudBaseOperator):
         endpoint_id = hook.extract_endpoint_id(endpoint)
         self.log.info("Endpoint was created. Endpoint ID: %s", endpoint_id)
 
-        context["ti"].xcom_push(key="endpoint_id", value=endpoint_id)
+        context["task_instance"].xcom_push(key="endpoint_id", value=endpoint_id)
         VertexAIEndpointLink.persist(context=context, endpoint_id=endpoint_id)
         return endpoint
 
@@ -292,7 +292,7 @@ class DeployModelOperator(GoogleCloudBaseOperator):
         deployed_model_id = hook.extract_deployed_model_id(deploy_model)
         self.log.info("Model was deployed. Deployed Model ID: %s", deployed_model_id)
 
-        context["ti"].xcom_push(key="deployed_model_id", value=deployed_model_id)
+        context["task_instance"].xcom_push(key="deployed_model_id", value=deployed_model_id)
         VertexAIModelLink.persist(context=context, model_id=deployed_model_id)
         return deploy_model
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/generative_model.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/generative_model.py
@@ -94,7 +94,7 @@ class TextEmbeddingModelGetEmbeddingsOperator(GoogleCloudBaseOperator):
         )
 
         self.log.info("Model response: %s", response)
-        context["ti"].xcom_push(key="model_response", value=response)
+        context["task_instance"].xcom_push(key="model_response", value=response)
 
         return response
 
@@ -173,7 +173,7 @@ class GenerativeModelGenerateContentOperator(GoogleCloudBaseOperator):
         )
 
         self.log.info("Model response: %s", response)
-        context["ti"].xcom_push(key="model_response", value=response)
+        context["task_instance"].xcom_push(key="model_response", value=response)
 
         return response
 
@@ -269,8 +269,10 @@ class SupervisedFineTuningTrainOperator(GoogleCloudBaseOperator):
         self.log.info("Tuned Model Name: %s", response.tuned_model_name)
         self.log.info("Tuned Model Endpoint Name: %s", response.tuned_model_endpoint_name)
 
-        context["ti"].xcom_push(key="tuned_model_name", value=response.tuned_model_name)
-        context["ti"].xcom_push(key="tuned_model_endpoint_name", value=response.tuned_model_endpoint_name)
+        context["task_instance"].xcom_push(key="tuned_model_name", value=response.tuned_model_name)
+        context["task_instance"].xcom_push(
+            key="tuned_model_endpoint_name", value=response.tuned_model_endpoint_name
+        )
 
         result = {
             "tuned_model_name": response.tuned_model_name,
@@ -340,8 +342,10 @@ class CountTokensOperator(GoogleCloudBaseOperator):
         self.log.info("Total tokens: %s", response.total_tokens)
         self.log.info("Total billable characters: %s", response.total_billable_characters)
 
-        context["ti"].xcom_push(key="total_tokens", value=response.total_tokens)
-        context["ti"].xcom_push(key="total_billable_characters", value=response.total_billable_characters)
+        context["task_instance"].xcom_push(key="total_tokens", value=response.total_tokens)
+        context["task_instance"].xcom_push(
+            key="total_billable_characters", value=response.total_billable_characters
+        )
 
 
 class RunEvaluationOperator(GoogleCloudBaseOperator):

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/hyperparameter_tuning_job.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/hyperparameter_tuning_job.py
@@ -257,7 +257,9 @@ class CreateHyperparameterTuningJobOperator(GoogleCloudBaseOperator):
         hyperparameter_tuning_job_id = hyperparameter_tuning_job.name
         self.log.info("Hyperparameter Tuning job was created. Job id: %s", hyperparameter_tuning_job_id)
 
-        context["ti"].xcom_push(key="hyperparameter_tuning_job_id", value=hyperparameter_tuning_job_id)
+        context["task_instance"].xcom_push(
+            key="hyperparameter_tuning_job_id", value=hyperparameter_tuning_job_id
+        )
         VertexAITrainingLink.persist(context=context, training_id=hyperparameter_tuning_job_id)
 
         if self.deferrable:

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/model_service.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/model_service.py
@@ -186,7 +186,7 @@ class GetModelOperator(GoogleCloudBaseOperator):
             )
             self.log.info("Model found. Model ID: %s", self.model_id)
 
-            context["ti"].xcom_push(key="model_id", value=self.model_id)
+            context["task_instance"].xcom_push(key="model_id", value=self.model_id)
             VertexAIModelLink.persist(context=context, model_id=self.model_id)
             return Model.to_dict(model)
         except NotFound:
@@ -453,7 +453,7 @@ class UploadModelOperator(GoogleCloudBaseOperator):
         model_id = hook.extract_model_id(model_resp)
         self.log.info("Model was uploaded. Model ID: %s", model_id)
 
-        context["ti"].xcom_push(key="model_id", value=model_id)
+        context["task_instance"].xcom_push(key="model_id", value=model_id)
         VertexAIModelLink.persist(context=context, model_id=model_id)
         return model_resp
 

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/pipeline_job.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/pipeline_job.py
@@ -195,7 +195,7 @@ class RunPipelineJobOperator(GoogleCloudBaseOperator):
         )
         pipeline_job_id = pipeline_job_obj.job_id
         self.log.info("Pipeline job was created. Job id: %s", pipeline_job_id)
-        context["ti"].xcom_push(key="pipeline_job_id", value=pipeline_job_id)
+        context["task_instance"].xcom_push(key="pipeline_job_id", value=pipeline_job_id)
         VertexAIPipelineJobLink.persist(context=context, pipeline_id=pipeline_job_id)
 
         if self.deferrable:

--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/ray.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/ray.py
@@ -190,7 +190,7 @@ class CreateRayClusterOperator(RayBaseOperator):
                 labels=self.labels,
             )
             cluster_id = self.hook.extract_cluster_id(cluster_path)
-            context["ti"].xcom_push(
+            context["task_instance"].xcom_push(
                 key="cluster_id",
                 value=cluster_id,
             )

--- a/providers/google/src/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service.py
+++ b/providers/google/src/airflow/providers/google/cloud/sensors/cloud_storage_transfer_service.py
@@ -103,7 +103,7 @@ class CloudDataTransferServiceJobStatusSensor(BaseSensorOperator):
         self.deferrable = deferrable
 
     def poke(self, context: Context) -> bool:
-        ti = context["ti"]
+        ti = context["task_instance"]
         hook = CloudDataTransferServiceHook(
             gcp_conn_id=self.gcp_cloud_conn_id,
             impersonation_chain=self.impersonation_chain,
@@ -159,5 +159,5 @@ class CloudDataTransferServiceJobStatusSensor(BaseSensorOperator):
         if event["status"] == "error":
             raise AirflowException(event["message"])
 
-        ti = context["ti"]
+        ti = context["task_instance"]
         ti.xcom_push(key="sensed_operations", value=event["operations"])

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_bigquery.py
@@ -447,7 +447,7 @@ class GCSToBigQueryOperator(BaseOperator):
                                 BigQueryTableLink.persist(**persist_kwargs)
 
             self.job_id = job.job_id
-            context["ti"].xcom_push(key="job_id", value=self.job_id)
+            context["task_instance"].xcom_push(key="job_id", value=self.job_id)
             if self.deferrable:
                 self.defer(
                     timeout=self.execution_timeout,

--- a/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_local.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/gcs_to_local.py
@@ -110,7 +110,9 @@ class GCSToLocalFilesystemOperator(BaseOperator):
             file_size = hook.get_size(bucket_name=self.bucket, object_name=self.object_name)
             if file_size < MAX_XCOM_SIZE:
                 file_bytes = hook.download(bucket_name=self.bucket, object_name=self.object_name)
-                context["ti"].xcom_push(key=self.store_to_xcom_key, value=str(file_bytes, self.file_encoding))
+                context["task_instance"].xcom_push(
+                    key=self.store_to_xcom_key, value=str(file_bytes, self.file_encoding)
+                )
             else:
                 raise AirflowException("The size of the downloaded file is too large to push to XCom!")
         else:

--- a/providers/google/src/airflow/providers/google/cloud/transfers/sheets_to_gcs.py
+++ b/providers/google/src/airflow/providers/google/cloud/transfers/sheets_to_gcs.py
@@ -130,5 +130,5 @@ class GoogleSheetsToGCSOperator(BaseOperator):
             gcs_path_to_file = self._upload_data(gcs_hook, sheet_hook, sheet_range, data)
             destination_array.append(gcs_path_to_file)
 
-        context["ti"].xcom_push(key="destination_objects", value=destination_array)
+        context["task_instance"].xcom_push(key="destination_objects", value=destination_array)
         return destination_array

--- a/providers/google/tests/unit/google/cloud/links/test_base_link.py
+++ b/providers/google/tests/unit/google/cloud/links/test_base_link.py
@@ -63,7 +63,7 @@ class TestBaseGoogleLink:
                 cluster_id=TEST_CLUSTER_ID,
                 project_id=TEST_PROJECT_ID,
             )
-            mock_context["ti"].xcom_push.assert_called_once_with(
+            mock_context["task_instance"].xcom_push.assert_called_once_with(
                 key=EXPECTED_GOOGLE_LINK_KEY,
                 value={
                     "location": TEST_LOCATION,

--- a/providers/google/tests/unit/google/cloud/links/test_cloud_run.py
+++ b/providers/google/tests/unit/google/cloud/links/test_cloud_run.py
@@ -42,7 +42,7 @@ class TestCloudRunJobLoggingLink:
 
     def test_persist(self):
         mock_context = mock.MagicMock()
-        mock_context["ti"] = mock.MagicMock()
+        mock_context["task_instance"] = mock.MagicMock()
         mock_context["task"] = mock.MagicMock()
 
         CloudRunJobLoggingLink.persist(
@@ -50,7 +50,7 @@ class TestCloudRunJobLoggingLink:
             log_uri=TEST_LOG_URI,
         )
 
-        mock_context["ti"].xcom_push.assert_called_once_with(
+        mock_context["task_instance"].xcom_push.assert_called_once_with(
             key=CloudRunJobLoggingLink.key,
             value={"log_uri": TEST_LOG_URI},
         )
@@ -69,7 +69,7 @@ class TestCloudRunJobLoggingLink:
         session.add(ti)
         session.commit()
 
-        link.persist(context={"ti": ti, "task": ti.task}, log_uri=TEST_LOG_URI)
+        link.persist(context={"task_instance": ti, "task": ti.task}, log_uri=TEST_LOG_URI)
 
         if mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(

--- a/providers/google/tests/unit/google/cloud/links/test_dataplex.py
+++ b/providers/google/tests/unit/google/cloud/links/test_dataplex.py
@@ -152,7 +152,7 @@ class TestDataplexTasksLink:
         session.add(ti)
         session.commit()
 
-        link.persist(context={"ti": ti, "task": ti.task})
+        link.persist(context={"task_instance": ti, "task": ti.task})
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
@@ -213,7 +213,7 @@ class TestDataplexCatalogEntryGroupLink:
         session.add(ti)
         session.commit()
 
-        link.persist(context={"ti": ti, "task": ti.task})
+        link.persist(context={"task_instance": ti, "task": ti.task})
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(

--- a/providers/google/tests/unit/google/cloud/links/test_translate.py
+++ b/providers/google/tests/unit/google/cloud/links/test_translate.py
@@ -64,7 +64,7 @@ class TestTranslationLegacyDatasetLink:
         session.commit()
 
         link.persist(
-            context={"ti": ti, "task": ti.task},
+            context={"task_instance": ti, "task": ti.task},
             dataset_id=DATASET,
             project_id=GCP_PROJECT_ID,
             location=GCP_LOCATION,
@@ -96,7 +96,7 @@ class TestTranslationDatasetListLink:
         )
         session.add(ti)
         session.commit()
-        link.persist(context={"ti": ti, "task": ti.task}, project_id=GCP_PROJECT_ID)
+        link.persist(context={"task_instance": ti, "task": ti.task}, project_id=GCP_PROJECT_ID)
 
         if AIRFLOW_V_3_0_PLUS and mock_supervisor_comms:
             mock_supervisor_comms.send.return_value = XComResult(
@@ -135,7 +135,7 @@ class TestTranslationLegacyModelLink:
             "location": GCP_LOCATION,
         }
         link.persist(
-            context={"ti": ti, "task": task},
+            context={"task_instance": ti, "task": task},
             dataset_id=DATASET,
             model_id=MODEL,
             project_id=GCP_PROJECT_ID,
@@ -179,7 +179,7 @@ class TestTranslationLegacyModelTrainLink:
             "location": GCP_LOCATION,
         }
         link.persist(
-            context={"ti": ti, "task": task},
+            context={"task_instance": ti, "task": task},
             dataset_id=DATASET,
             project_id=GCP_PROJECT_ID,
             location=GCP_LOCATION,

--- a/providers/google/tests/unit/google/cloud/links/test_vertex_ai.py
+++ b/providers/google/tests/unit/google/cloud/links/test_vertex_ai.py
@@ -45,7 +45,7 @@ class TestVertexAIRayClusterLink:
 
     def test_persist(self):
         mock_context = mock.MagicMock()
-        mock_context["ti"] = mock.MagicMock(location=TEST_LOCATION, project_id=TEST_PROJECT_ID)
+        mock_context["task_instance"] = mock.MagicMock(location=TEST_LOCATION, project_id=TEST_PROJECT_ID)
         mock_context["task"] = mock.MagicMock()
 
         VertexAIRayClusterLink.persist(
@@ -55,7 +55,7 @@ class TestVertexAIRayClusterLink:
             project_id=TEST_PROJECT_ID,
         )
 
-        mock_context["ti"].xcom_push.assert_called_once_with(
+        mock_context["task_instance"].xcom_push.assert_called_once_with(
             key=EXPECTED_VERTEX_AI_RAY_CLUSTER_LINK_KEY,
             value={
                 "location": TEST_LOCATION,
@@ -73,7 +73,7 @@ class TestVertexAIRayClusterListLink:
 
     def test_persist(self):
         mock_context = mock.MagicMock()
-        mock_context["ti"] = mock.MagicMock(project_id=TEST_PROJECT_ID)
+        mock_context["task_instance"] = mock.MagicMock(project_id=TEST_PROJECT_ID)
         mock_context["task"] = mock.MagicMock()
 
         VertexAIRayClusterListLink.persist(
@@ -81,7 +81,7 @@ class TestVertexAIRayClusterListLink:
             project_id=TEST_PROJECT_ID,
         )
 
-        mock_context["ti"].xcom_push.assert_called_once_with(
+        mock_context["task_instance"].xcom_push.assert_called_once_with(
             key=EXPECTED_VERTEX_AI_RAY_CLUSTER_LIST_LINK_KEY,
             value={
                 "project_id": TEST_PROJECT_ID,

--- a/providers/google/tests/unit/google/cloud/openlineage/test_utils.py
+++ b/providers/google/tests/unit/google/cloud/openlineage/test_utils.py
@@ -104,7 +104,7 @@ EXAMPLE_TEMPLATE = {
     ],
 }
 EXAMPLE_CONTEXT = {
-    "ti": MagicMock(
+    "task_instance": MagicMock(
         dag_id="dag_id",
         task_id="task_id",
         try_number=1,

--- a/providers/google/tests/unit/google/cloud/operators/test_automl.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_automl.py
@@ -130,7 +130,7 @@ class TestAutoMLPredictOperator:
     def test_execute(self, mock_hook, mock_link_persist):
         mock_hook.return_value.predict.return_value = PredictResponse()
         mock_hook.return_value.get_model.return_value = mock.MagicMock(**MODEL)
-        mock_context = {"ti": mock.MagicMock()}
+        mock_context = {"task_instance": mock.MagicMock()}
         with pytest.warns(AirflowProviderDeprecationWarning):
             op = AutoMLPredictOperator(
                 model_id=MODEL_ID,

--- a/providers/google/tests/unit/google/cloud/operators/test_bigquery_dts.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigquery_dts.py
@@ -61,7 +61,7 @@ class TestBigQueryCreateDataTransferOperator:
         )
         ti = mock.MagicMock()
 
-        return_value = op.execute({"ti": ti, "task": ti.task})
+        return_value = op.execute({"task_instance": ti, "task": ti.task})
 
         mock_hook.return_value.create_transfer_config.assert_called_once_with(
             authorization_code=None,
@@ -115,7 +115,7 @@ class TestBigQueryDataTransferServiceStartTransferRunsOperator:
         )
         ti = mock.MagicMock()
 
-        op.execute({"ti": ti, "task": ti.task})
+        op.execute({"task_instance": ti, "task": ti.task})
 
         mock_hook.return_value.start_manual_transfer_runs.assert_called_once_with(
             transfer_config_id=TRANSFER_CONFIG_ID,
@@ -146,7 +146,7 @@ class TestBigQueryDataTransferServiceStartTransferRunsOperator:
         )
         ti = mock.MagicMock()
 
-        op.execute({"ti": ti, "task": ti.task})
+        op.execute({"task_instance": ti, "task": ti.task})
 
         defer_method.assert_called_once()
 
@@ -205,7 +205,7 @@ class TestBigQueryDataTransferServiceStartTransferRunsOperator:
         op = BigQueryDataTransferServiceStartTransferRunsOperator(
             transfer_config_id=TRANSFER_CONFIG_ID, task_id="id", project_id=PROJECT_ID
         )
-        op.execute({"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute({"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         result = op.get_openlineage_facets_on_complete(None)
         assert not result.run_facets
         assert not result.job_facets
@@ -281,7 +281,7 @@ class TestBigQueryDataTransferServiceStartTransferRunsOperator:
         op = BigQueryDataTransferServiceStartTransferRunsOperator(
             transfer_config_id=TRANSFER_CONFIG_ID, task_id="id", project_id=PROJECT_ID
         )
-        op.execute({"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute({"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         result = op.get_openlineage_facets_on_complete(None)
         assert not result.run_facets
         assert not result.job_facets
@@ -315,7 +315,7 @@ class TestBigQueryDataTransferServiceStartTransferRunsOperator:
         op = BigQueryDataTransferServiceStartTransferRunsOperator(
             transfer_config_id=TRANSFER_CONFIG_ID, task_id="id", project_id=PROJECT_ID
         )
-        op.execute({"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute({"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         result = op.get_openlineage_facets_on_complete(None)
         assert len(result.job_facets) == 1
         assert result.job_facets["sql"].query == "SELECT a,b,c from x.y.z"
@@ -353,7 +353,7 @@ class TestBigQueryDataTransferServiceStartTransferRunsOperator:
         op = BigQueryDataTransferServiceStartTransferRunsOperator(
             transfer_config_id=TRANSFER_CONFIG_ID, task_id="id", project_id=PROJECT_ID
         )
-        op.execute({"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute({"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         result = op.get_openlineage_facets_on_complete(None)
         assert not result.job_facets
         assert len(result.run_facets) == 1
@@ -390,7 +390,7 @@ class TestBigQueryDataTransferServiceStartTransferRunsOperator:
         op = BigQueryDataTransferServiceStartTransferRunsOperator(
             transfer_config_id=TRANSFER_CONFIG_ID, task_id="id", project_id=PROJECT_ID, deferrable=True
         )
-        op.execute({"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute({"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         # `defer` is mocked so it will not call the `execute_completed`, so we do it manually.
         op.execute_completed(
             mock.MagicMock(), {"status": "done", "run_id": 123, "config_id": 321, "message": "msg"}

--- a/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_bigtable.py
@@ -100,7 +100,7 @@ class TestBigtableInstanceCreate:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -120,7 +120,7 @@ class TestBigtableInstanceCreate:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
 
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -178,7 +178,7 @@ class TestBigtableInstanceCreate:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -210,7 +210,7 @@ class TestBigtableInstanceCreate:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -243,7 +243,7 @@ class TestBigtableInstanceUpdate:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -268,7 +268,7 @@ class TestBigtableInstanceUpdate:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -797,7 +797,7 @@ class TestBigtableTableCreate:
             impersonation_chain=IMPERSONATION_CHAIN,
         )
         instance = mock_hook.return_value.get_instance.return_value = mock.Mock(Instance)
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,

--- a/providers/google/tests/unit/google/cloud/operators/test_cloud_build.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_cloud_build.py
@@ -426,7 +426,7 @@ def test_async_create_build_fires_correct_trigger_should_execute_successfully(
     )
 
     with pytest.raises(TaskDeferred) as exc:
-        ti.task.execute({"ti": ti, "task_instance": ti})
+        ti.task.execute({"task_instance": ti})
 
     assert isinstance(exc.value.trigger, CloudBuildCreateBuildTrigger), (
         "Trigger is not a CloudBuildCreateBuildTrigger"
@@ -472,7 +472,7 @@ def test_async_create_build_correct_logging_should_execute_successfully(
 
     with mock.patch.object(ti.task.log, "info") as mock_log_info:
         ti.task.execute_complete(
-            context={"ti": ti, "task": ti.task},
+            context={"task_instance": ti, "task": ti.task},
             event={
                 "instance": TEST_BUILD_INSTANCE,
                 "status": "success",
@@ -550,7 +550,6 @@ def create_context(task):
         "dag": dag,
         "run_id": dag_run.run_id,
         "task": task,
-        "ti": task_instance,
         "task_instance": task_instance,
         "logical_date": logical_date,
     }

--- a/providers/google/tests/unit/google/cloud/operators/test_datacatalog.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_datacatalog.py
@@ -164,7 +164,7 @@ class TestCloudDataCatalogCreateEntryOperator:
                 impersonation_chain=TEST_IMPERSONATION_CHAIN,
             )
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
         if not AIRFLOW_V_3_0_PLUS:
             mock_context["task"] = task  # type: ignore[assignment]
         result = task.execute(context=mock_context)  # type: ignore[arg-type]
@@ -208,7 +208,7 @@ class TestCloudDataCatalogCreateEntryOperator:
                 impersonation_chain=TEST_IMPERSONATION_CHAIN,
             )
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
         if not AIRFLOW_V_3_0_PLUS:
             mock_context["task"] = task  # type: ignore[assignment]
         result = task.execute(context=mock_context)  # type: ignore[arg-type]
@@ -262,7 +262,7 @@ class TestCloudDataCatalogCreateEntryGroupOperator:
                 impersonation_chain=TEST_IMPERSONATION_CHAIN,
             )
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
         if not AIRFLOW_V_3_0_PLUS:
             mock_context["task"] = task  # type: ignore[assignment]
         result = task.execute(context=mock_context)  # type: ignore[arg-type]
@@ -308,7 +308,7 @@ class TestCloudDataCatalogCreateTagOperator:
                 impersonation_chain=TEST_IMPERSONATION_CHAIN,
             )
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
         if not AIRFLOW_V_3_0_PLUS:
             mock_context["task"] = task  # type: ignore[assignment]
         result = task.execute(context=mock_context)  # type: ignore[arg-type]
@@ -354,7 +354,7 @@ class TestCloudDataCatalogCreateTagTemplateOperator:
                 impersonation_chain=TEST_IMPERSONATION_CHAIN,
             )
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
         if not AIRFLOW_V_3_0_PLUS:
             mock_context["task"] = task  # type: ignore[assignment]
         result = task.execute(context=mock_context)  # type: ignore[arg-type]
@@ -399,7 +399,7 @@ class TestCloudDataCatalogCreateTagTemplateFieldOperator:
                 impersonation_chain=TEST_IMPERSONATION_CHAIN,
             )
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
         if not AIRFLOW_V_3_0_PLUS:
             mock_context["task"] = task  # type: ignore[assignment]
         result = task.execute(context=mock_context)  # type: ignore[arg-type]

--- a/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_dataproc.py
@@ -407,7 +407,7 @@ BATCH = {
     },
 }
 EXAMPLE_CONTEXT = {
-    "ti": MagicMock(
+    "task_instance": MagicMock(
         dag_id="dag_id",
         task_id="task_id",
         try_number=1,
@@ -468,15 +468,15 @@ class DataprocTestBase:
 
     def setup_method(self):
         self.mock_ti = MagicMock()
-        self.mock_context = {"ti": self.mock_ti, "task": self.mock_ti.task}
+        self.mock_context = {"task_instance": self.mock_ti, "task": self.mock_ti.task}
         self.extra_links_manager_mock = Mock()
-        self.extra_links_manager_mock.attach_mock(self.mock_ti, "ti")
+        self.extra_links_manager_mock.attach_mock(self.mock_ti, "task_instance")
 
     def tearDown(self):
         self.mock_ti = MagicMock()
-        self.mock_context = {"ti": self.mock_ti, "task": self.mock_ti.task}
+        self.mock_context = {"task_instance": self.mock_ti, "task": self.mock_ti.task}
         self.extra_links_manager_mock = Mock()
-        self.extra_links_manager_mock.attach_mock(self.mock_ti, "ti")
+        self.extra_links_manager_mock.attach_mock(self.mock_ti, "task_instance")
 
     @classmethod
     def tearDownClass(cls):
@@ -1474,7 +1474,7 @@ class TestDataprocSubmitJobOperator(DataprocJobTestBase):
             },
         }
         context = {
-            "ti": MagicMock(
+            "task_instance": MagicMock(
                 dag_id="dag_id",
                 task_id="task_id",
                 try_number=1,

--- a/providers/google/tests/unit/google/cloud/operators/test_datastore.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_datastore.py
@@ -58,7 +58,7 @@ class TestCloudDatastoreExportEntitiesOperator:
             project_id=PROJECT_ID,
             bucket=BUCKET,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
 
         mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID, impersonation_chain=None)
         mock_hook.return_value.export_to_storage_bucket.assert_called_once_with(
@@ -87,7 +87,7 @@ class TestCloudDatastoreImportEntitiesOperator:
             bucket=BUCKET,
             file=FILE,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
 
         mock_hook.assert_called_once_with(CONN_ID, impersonation_chain=None)
         mock_hook.return_value.import_from_storage_bucket.assert_called_once_with(
@@ -112,7 +112,7 @@ class TestCloudDatastoreAllocateIds:
             project_id=PROJECT_ID,
             partial_keys=partial_keys,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
 
         mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID, impersonation_chain=None)
         mock_hook.return_value.allocate_ids.assert_called_once_with(
@@ -143,7 +143,7 @@ class TestCloudDatastoreCommit:
         op = CloudDatastoreCommitOperator(
             task_id="test_task", gcp_conn_id=CONN_ID, project_id=PROJECT_ID, body=BODY
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
 
         mock_hook.assert_called_once_with(gcp_conn_id=CONN_ID, impersonation_chain=None)
         mock_hook.return_value.commit.assert_called_once_with(project_id=PROJECT_ID, body=BODY)

--- a/providers/google/tests/unit/google/cloud/operators/test_functions.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_functions.py
@@ -717,7 +717,7 @@ class TestGcfFunctionInvokeOperator:
             impersonation_chain=impersonation_chain,
         )
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
         if not AIRFLOW_V_3_0_PLUS:
             mock_context["task"] = op
         op.execute(mock_context)

--- a/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_kubernetes_engine.py
@@ -1025,7 +1025,7 @@ class TestGKEListJobsOperator:
         mock_to_dict_value = mock_to_dict.return_value
 
         mock_ti = mock.MagicMock()
-        context = {"ti": mock_ti, "task": mock.MagicMock()}
+        context = {"task_instance": mock_ti, "task": mock.MagicMock()}
 
         result = self.operator.execute(context=context)
 
@@ -1057,7 +1057,7 @@ class TestGKEListJobsOperator:
         mock_to_dict_value = mock_to_dict.return_value
 
         mock_ti = mock.MagicMock()
-        context = {"ti": mock_ti, "task": mock.MagicMock()}
+        context = {"task_instance": mock_ti, "task": mock.MagicMock()}
 
         self.operator.namespace = K8S_NAMESPACE
         result = self.operator.execute(context=context)
@@ -1089,7 +1089,7 @@ class TestGKEListJobsOperator:
         mock_to_dict_value = mock_to_dict.return_value
 
         mock_ti = mock.MagicMock()
-        context = {"ti": mock_ti, "task": mock.MagicMock()}
+        context = {"task_instance": mock_ti, "task": mock.MagicMock()}
 
         self.operator.do_xcom_push = False
         result = self.operator.execute(context=context)

--- a/providers/google/tests/unit/google/cloud/operators/test_looker.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_looker.py
@@ -48,11 +48,11 @@ class LookerTestBase:
 
     def setup_method(self):
         self.mock_ti = MagicMock()
-        self.mock_context = {"ti": self.mock_ti}
+        self.mock_context = {"task_instance": self.mock_ti}
 
     def tearDown(self):
         self.mock_ti = MagicMock()
-        self.mock_context = {"ti": self.mock_ti}
+        self.mock_context = {"task_instance": self.mock_ti}
 
     @classmethod
     def tearDownClass(cls):

--- a/providers/google/tests/unit/google/cloud/operators/test_managed_kafka.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_managed_kafka.py
@@ -104,7 +104,7 @@ class TestManagedKafkaCreateClusterOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_cluster.assert_called_once_with(
             location=GCP_LOCATION,
@@ -142,7 +142,7 @@ class TestManagedKafkaListClustersOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_clusters.assert_called_once_with(
             location=GCP_LOCATION,
@@ -172,7 +172,7 @@ class TestManagedKafkaGetClusterOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.get_cluster.assert_called_once_with(
             location=GCP_LOCATION,
@@ -202,7 +202,7 @@ class TestManagedKafkaUpdateClusterOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.update_cluster.assert_called_once_with(
             project_id=GCP_PROJECT,
@@ -262,7 +262,7 @@ class TestManagedKafkaCreateTopicOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_topic.assert_called_once_with(
             location=GCP_LOCATION,
@@ -297,7 +297,7 @@ class TestManagedKafkaListTopicsOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_topics.assert_called_once_with(
             location=GCP_LOCATION,
@@ -327,7 +327,7 @@ class TestManagedKafkaGetTopicOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.get_topic.assert_called_once_with(
             location=GCP_LOCATION,
@@ -358,7 +358,7 @@ class TestManagedKafkaUpdateTopicOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.update_topic.assert_called_once_with(
             project_id=GCP_PROJECT,
@@ -422,7 +422,7 @@ class TestManagedKafkaListConsumerGroupsOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_consumer_groups.assert_called_once_with(
             location=GCP_LOCATION,
@@ -452,7 +452,7 @@ class TestManagedKafkaGetConsumerGroupOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.get_consumer_group.assert_called_once_with(
             location=GCP_LOCATION,
@@ -483,7 +483,7 @@ class TestManagedKafkaUpdateConsumerGroupOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.update_consumer_group.assert_called_once_with(
             project_id=GCP_PROJECT,

--- a/providers/google/tests/unit/google/cloud/operators/test_translate.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_translate.py
@@ -183,7 +183,7 @@ class TestTranslateTextBatchOperator:
             timeout=TIMEOUT,
             retry=None,
         )
-        context = {"ti": mock.MagicMock()}
+        context = {"task_instance": mock.MagicMock()}
         result = op.execute(context=context)
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -250,7 +250,7 @@ class TestTranslateDatasetCreate:
             retry=None,
         )
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
         result = op.execute(context=mock_context)
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -450,7 +450,7 @@ class TestTranslateModelCreate:
             retry=None,
         )
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
         result = op.execute(context=mock_context)
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -619,7 +619,7 @@ class TestTranslateDocumentBatchOperator:
             timeout=TIMEOUT,
             retry=None,
         )
-        context = {"ti": mock.MagicMock()}
+        context = {"task_instance": mock.MagicMock()}
         result = op.execute(context=context)
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -693,7 +693,7 @@ class TestTranslateDocumentOperator:
             timeout=TIMEOUT,
             retry=None,
         )
-        context = {"ti": mock.MagicMock()}
+        context = {"task_instance": mock.MagicMock()}
         result = op.execute(context=context)
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -759,7 +759,7 @@ class TestTranslateGlossaryCreate:
             retry=None,
         )
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
         result = op.execute(context=mock_context)
 
         mock_hook.assert_called_once_with(

--- a/providers/google/tests/unit/google/cloud/operators/test_vertex_ai.py
+++ b/providers/google/tests/unit/google/cloud/operators/test_vertex_ai.py
@@ -266,7 +266,7 @@ class TestVertexAICreateCustomContainerTrainingJobOperator:
             dataset_id=TEST_DATASET_ID,
             parent_model=TEST_PARENT_MODEL,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_dataset.assert_called_once_with(name=TEST_DATASET_ID)
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_custom_container_training_job.assert_called_once_with(
@@ -355,7 +355,7 @@ class TestVertexAICreateCustomContainerTrainingJobOperator:
             dataset_id=TEST_DATASET_ID,
             parent_model=VERSIONED_TEST_PARENT_MODEL,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.return_value.create_custom_container_training_job.assert_called_once_with(
             staging_bucket=STAGING_BUCKET,
             display_name=DISPLAY_NAME,
@@ -437,7 +437,7 @@ class TestVertexAICreateCustomContainerTrainingJobOperator:
         )
         mock_hook.return_value.exists.return_value = False
         with pytest.raises(TaskDeferred) as exc:
-            task.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+            task.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         assert isinstance(exc.value.trigger, CustomContainerTrainingJobTrigger), (
             "Trigger is not a CustomContainerTrainingJobTrigger"
         )
@@ -474,7 +474,7 @@ class TestVertexAICreateCustomContainerTrainingJobOperator:
         mock_hook_extract_model_id.return_value = "test-model"
 
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
 
         actual_result = task.execute_complete(
             context=mock_context,
@@ -549,7 +549,7 @@ class TestVertexAICreateCustomContainerTrainingJobOperator:
         hook_extract_model_id.return_value = None
 
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
 
         actual_result = task.execute_complete(
             context=mock_context,
@@ -594,7 +594,7 @@ class TestVertexAICreateCustomPythonPackageTrainingJobOperator:
             dataset_id=TEST_DATASET_ID,
             parent_model=TEST_PARENT_MODEL,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_dataset.assert_called_once_with(name=TEST_DATASET_ID)
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_custom_python_package_training_job.assert_called_once_with(
@@ -685,7 +685,7 @@ class TestVertexAICreateCustomPythonPackageTrainingJobOperator:
             dataset_id=TEST_DATASET_ID,
             parent_model=VERSIONED_TEST_PARENT_MODEL,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.return_value.create_custom_python_package_training_job.assert_called_once_with(
             staging_bucket=STAGING_BUCKET,
             display_name=DISPLAY_NAME,
@@ -769,7 +769,7 @@ class TestVertexAICreateCustomPythonPackageTrainingJobOperator:
         )
         mock_hook.return_value.exists.return_value = False
         with pytest.raises(TaskDeferred) as exc:
-            task.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+            task.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         assert isinstance(exc.value.trigger, CustomPythonPackageTrainingJobTrigger), (
             "Trigger is not a CustomPythonPackageTrainingJobTrigger"
         )
@@ -812,7 +812,7 @@ class TestVertexAICreateCustomPythonPackageTrainingJobOperator:
         hook_extract_model_id.return_value = "test-model"
 
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
 
         actual_result = task.execute_complete(
             context=mock_context,
@@ -890,7 +890,7 @@ class TestVertexAICreateCustomPythonPackageTrainingJobOperator:
 
         expected_result = None
         actual_result = task.execute_complete(
-            context={"ti": mock_ti},
+            context={"task_instance": mock_ti},
             event={"status": "success", "message": "", "job": TEST_TRAINING_PIPELINE_DATA_NO_MODEL},
         )
         mock_ti.xcom_push.assert_called_once()
@@ -924,7 +924,7 @@ class TestVertexAICreateCustomTrainingJobOperator:
             dataset_id=TEST_DATASET_ID,
             parent_model=TEST_PARENT_MODEL,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_dataset.assert_called_once_with(name=TEST_DATASET_ID)
         mock_hook.return_value.create_custom_training_job.assert_called_once_with(
@@ -1008,7 +1008,7 @@ class TestVertexAICreateCustomTrainingJobOperator:
             dataset_id=TEST_DATASET_ID,
             parent_model=VERSIONED_TEST_PARENT_MODEL,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.return_value.create_custom_training_job.assert_called_once_with(
             staging_bucket=STAGING_BUCKET,
             display_name=DISPLAY_NAME,
@@ -1085,7 +1085,7 @@ class TestVertexAICreateCustomTrainingJobOperator:
         )
         mock_hook.return_value.exists.return_value = False
         with pytest.raises(TaskDeferred) as exc:
-            task.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+            task.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         assert isinstance(exc.value.trigger, CustomTrainingJobTrigger), (
             "Trigger is not a CustomTrainingJobTrigger"
         )
@@ -1120,7 +1120,7 @@ class TestVertexAICreateCustomTrainingJobOperator:
 
         mock_ti = mock.MagicMock()
         actual_result = task.execute_complete(
-            context={"ti": mock_ti},
+            context={"task_instance": mock_ti},
             event={
                 "status": "success",
                 "message": "",
@@ -1128,7 +1128,7 @@ class TestVertexAICreateCustomTrainingJobOperator:
             },
         )
         mock_ti.xcom_push.assert_called_with(key="model_id", value="test-model")
-        mock_link_persist.assert_called_once_with(context={"ti": mock_ti}, model_id="test-model")
+        mock_link_persist.assert_called_once_with(context={"task_instance": mock_ti}, model_id="test-model")
         assert actual_result == expected_result
 
     def test_execute_complete_error_status_raises_exception(self):
@@ -1178,7 +1178,7 @@ class TestVertexAICreateCustomTrainingJobOperator:
         hook_extract_model_id.return_value = None
 
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
 
         actual_result = task.execute_complete(
             context=mock_context, event={"status": "success", "message": "", "job": {}}
@@ -1271,7 +1271,7 @@ class TestVertexAIListCustomTrainingJobOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_training_pipelines.assert_called_once_with(
             region=GCP_LOCATION,
@@ -1301,7 +1301,7 @@ class TestVertexAICreateDatasetOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_dataset.assert_called_once_with(
             region=GCP_LOCATION,
@@ -1453,7 +1453,7 @@ class TestVertexAIListDatasetsOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_datasets.assert_called_once_with(
             region=GCP_LOCATION,
@@ -1525,7 +1525,7 @@ class TestVertexAICreateAutoMLForecastingTrainingJobOperator:
             parent_model=TEST_PARENT_MODEL,
             holiday_regions=TEST_TRAINING_DATA_HOLIDAY_REGIONS,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_dataset.assert_called_once_with(dataset_name=TEST_DATASET_ID)
         mock_hook.return_value.create_auto_ml_forecasting_training_job.assert_called_once_with(
@@ -1596,7 +1596,7 @@ class TestVertexAICreateAutoMLForecastingTrainingJobOperator:
             parent_model=VERSIONED_TEST_PARENT_MODEL,
             holiday_regions=TEST_TRAINING_DATA_HOLIDAY_REGIONS,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.return_value.create_auto_ml_forecasting_training_job.assert_called_once_with(
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,
@@ -1661,7 +1661,7 @@ class TestVertexAICreateAutoMLImageTrainingJobOperator:
             project_id=GCP_PROJECT,
             parent_model=TEST_PARENT_MODEL,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_dataset.assert_called_once_with(dataset_name=TEST_DATASET_ID)
         mock_hook.return_value.create_auto_ml_image_training_job.assert_called_once_with(
@@ -1711,7 +1711,7 @@ class TestVertexAICreateAutoMLImageTrainingJobOperator:
             project_id=GCP_PROJECT,
             parent_model=VERSIONED_TEST_PARENT_MODEL,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.return_value.create_auto_ml_image_training_job.assert_called_once_with(
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,
@@ -1765,7 +1765,7 @@ class TestVertexAICreateAutoMLTabularTrainingJobOperator:
             project_id=GCP_PROJECT,
             parent_model=TEST_PARENT_MODEL,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_dataset.assert_called_once_with(
             dataset_name=TEST_DATASET_ID, project=GCP_PROJECT, credentials="creds"
@@ -1827,7 +1827,7 @@ class TestVertexAICreateAutoMLTabularTrainingJobOperator:
             project_id=GCP_PROJECT,
             parent_model=VERSIONED_TEST_PARENT_MODEL,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.return_value.create_auto_ml_tabular_training_job.assert_called_once_with(
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,
@@ -1882,7 +1882,7 @@ class TestVertexAICreateAutoMLVideoTrainingJobOperator:
             project_id=GCP_PROJECT,
             parent_model=TEST_PARENT_MODEL,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_dataset.assert_called_once_with(dataset_name=TEST_DATASET_ID)
         mock_hook.return_value.create_auto_ml_video_training_job.assert_called_once_with(
@@ -1925,7 +1925,7 @@ class TestVertexAICreateAutoMLVideoTrainingJobOperator:
             project_id=GCP_PROJECT,
             parent_model=VERSIONED_TEST_PARENT_MODEL,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.return_value.create_auto_ml_video_training_job.assert_called_once_with(
             project_id=GCP_PROJECT,
             region=GCP_LOCATION,
@@ -2021,7 +2021,7 @@ class TestVertexAIListAutoMLTrainingJobOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_training_pipelines.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2056,7 +2056,7 @@ class TestVertexAICreateBatchPredictionJobOperator:
             create_request_timeout=TEST_CREATE_REQUEST_TIMEOUT,
             batch_size=TEST_BATCH_SIZE,
         )
-        context = {"ti": mock.MagicMock(), "task": mock.MagicMock()}
+        context = {"task_instance": mock.MagicMock(), "task": mock.MagicMock()}
         op.execute(context=context)
 
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
@@ -2111,7 +2111,7 @@ class TestVertexAICreateBatchPredictionJobOperator:
             batch_size=TEST_BATCH_SIZE,
             deferrable=True,
         )
-        context = {"ti": mock.MagicMock(), "task": mock.MagicMock()}
+        context = {"task_instance": mock.MagicMock(), "task": mock.MagicMock()}
         with (
             pytest.raises(TaskDeferred) as exception_info,
             pytest.warns(
@@ -2164,7 +2164,7 @@ class TestVertexAICreateBatchPredictionJobOperator:
     @mock.patch(VERTEX_AI_PATH.format("batch_prediction_job.BatchPredictionJobHook"))
     def test_execute_complete(self, mock_hook):
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
         mock_job = {"name": TEST_JOB_DISPLAY_NAME}
         event = {
             "status": "success",
@@ -2252,7 +2252,7 @@ class TestVertexAIListBatchPredictionJobsOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_batch_prediction_jobs.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2283,7 +2283,7 @@ class TestVertexAICreateEndpointOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_endpoint.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2339,7 +2339,7 @@ class TestVertexAIDeployModelOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.deploy_model.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2377,7 +2377,7 @@ class TestVertexAIListEndpointsOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_endpoints.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2441,7 +2441,7 @@ class TestVertexAICreateHyperparameterTuningJobOperator:
             max_trial_count=15,
             parallel_trial_count=3,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_hyperparameter_tuning_job.assert_called_once_with(
             project_id=GCP_PROJECT,
@@ -2491,7 +2491,7 @@ class TestVertexAICreateHyperparameterTuningJobOperator:
             parallel_trial_count=3,
             deferrable=True,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_defer.assert_called_once()
 
     @mock.patch(VERTEX_AI_PATH.format("hyperparameter_tuning_job.HyperparameterTuningJobHook"))
@@ -2562,7 +2562,7 @@ class TestVertexAIGetHyperparameterTuningJobOperator:
             project_id=GCP_PROJECT,
             hyperparameter_tuning_job_id=TEST_HYPERPARAMETER_TUNING_JOB_ID,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.get_hyperparameter_tuning_job.assert_called_once_with(
             project_id=GCP_PROJECT,
@@ -2619,7 +2619,7 @@ class TestVertexAIListHyperparameterTuningJobOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_hyperparameter_tuning_jobs.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2649,7 +2649,7 @@ class TestVertexAIExportModelOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.export_model.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2713,7 +2713,7 @@ class TestVertexAIListModelsOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_models.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2744,7 +2744,7 @@ class TestVertexAIUploadModelOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.upload_model.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2771,7 +2771,7 @@ class TestVertexAIUploadModelOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.upload_model.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2799,7 +2799,7 @@ class TestVertexAIGetModelsOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.get_model.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2826,7 +2826,7 @@ class TestVertexAIListModelVersionsOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_model_versions.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2853,7 +2853,7 @@ class TestVertexAISetDefaultVersionOnModelOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.set_version_as_default.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2881,7 +2881,7 @@ class TestVertexAIAddVersionAliasesOnModelOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.add_version_aliases.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2910,7 +2910,7 @@ class TestVertexAIDeleteVersionAliasesOnModelOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.delete_version_aliases.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2938,7 +2938,7 @@ class TestVertexAIDeleteModelVersionOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.delete_model_version.assert_called_once_with(
             region=GCP_LOCATION,
@@ -2975,7 +2975,7 @@ class TestVertexAIRunPipelineJobOperator:
             create_request_timeout=None,
             experiment=None,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.submit_pipeline_job.assert_called_once_with(
             project_id=GCP_PROJECT,
@@ -3011,7 +3011,7 @@ class TestVertexAIRunPipelineJobOperator:
         )
         mock_hook.return_value.exists.return_value = False
         with pytest.raises(TaskDeferred) as exc:
-            task.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+            task.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         assert isinstance(exc.value.trigger, RunPipelineJobTrigger), "Trigger is not a RunPipelineJobTrigger"
 
     @mock.patch(VERTEX_AI_PATH.format("pipeline_job.PipelineJobHook"))
@@ -3033,7 +3033,7 @@ class TestVertexAIRunPipelineJobOperator:
         mock_hook.return_value.exists.return_value = False
 
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
 
         actual_result = task.execute_complete(
             context=mock_context, event={"status": "success", "message": "", "job": expected_pipeline_job}
@@ -3070,7 +3070,7 @@ class TestVertexAIGetPipelineJobOperator:
             project_id=GCP_PROJECT,
             pipeline_job_id=TEST_PIPELINE_JOB_ID,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.get_pipeline_job.assert_called_once_with(
             project_id=GCP_PROJECT,
@@ -3127,7 +3127,7 @@ class TestVertexAIListPipelineJobOperator:
             timeout=TIMEOUT,
             metadata=METADATA,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_pipeline_jobs.assert_called_once_with(
             region=GCP_LOCATION,
@@ -3165,7 +3165,7 @@ class TestVertexAICreateRayClusterOperator:
             reserved_ip_ranges=None,
             labels=None,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.create_ray_cluster.assert_called_once_with(
             location=GCP_LOCATION,
@@ -3196,7 +3196,7 @@ class TestVertexAIListRayClustersOperator:
             location=GCP_LOCATION,
             project_id=GCP_PROJECT,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.list_ray_clusters.assert_called_once_with(
             location=GCP_LOCATION,
@@ -3215,7 +3215,7 @@ class TestVertexAIGetRayClusterOperator:
             location=GCP_LOCATION,
             project_id=GCP_PROJECT,
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.get_ray_cluster.assert_called_once_with(
             location=GCP_LOCATION,
@@ -3236,7 +3236,7 @@ class TestVertexAIUpdateRayClusterOperator:
             cluster_id=TEST_CLUSTER_ID,
             worker_node_types=[TEST_NODE_RESOURCES],
         )
-        op.execute(context={"ti": mock.MagicMock(), "task": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock(), "task": mock.MagicMock()})
         mock_hook.assert_called_once_with(gcp_conn_id=GCP_CONN_ID, impersonation_chain=IMPERSONATION_CHAIN)
         mock_hook.return_value.update_ray_cluster.assert_called_once_with(
             project_id=GCP_PROJECT,

--- a/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_experiment_service.py
+++ b/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_experiment_service.py
@@ -58,7 +58,7 @@ class TestVertexAICreateExperimentOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -84,7 +84,7 @@ class TestVertexAIDeleteExperimentOperator:
             impersonation_chain=IMPERSONATION_CHAIN,
             delete_backing_tensorboard_runs=TEST_DELETE_BACKING_TENSORBOARD_RUNS,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -110,7 +110,7 @@ class TestVertexAICreateExperimentRunOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -136,7 +136,7 @@ class TestVertexAIListExperimentRunsOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -161,7 +161,7 @@ class TestVertexAIUpdateExperimentRunStateOperator:
             impersonation_chain=IMPERSONATION_CHAIN,
             new_state=TEST_TARGET_STATE,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -187,7 +187,7 @@ class TestVertexAIDeleteExperimentRunOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,

--- a/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_feature_store.py
+++ b/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_feature_store.py
@@ -78,7 +78,7 @@ class TestSyncFeatureViewOperator:
             impersonation_chain=IMPERSONATION_CHAIN,
         )
 
-        response = op.execute(context={"ti": mock.MagicMock()})
+        response = op.execute(context={"task_instance": mock.MagicMock()})
         # Verify hook initialization
         mock_hook_class.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -116,7 +116,7 @@ class TestGetFeatureViewSyncOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        response = op.execute(context={"ti": mock.MagicMock()})
+        response = op.execute(context={"task_instance": mock.MagicMock()})
         # Verify hook initialization
         mock_hook_class.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -166,7 +166,7 @@ class TestCreateFeatureOnlineStoreOperator:
             impersonation_chain=IMPERSONATION_CHAIN,
             **common_kwargs,
         )
-        result = op.execute(context={"ti": mock.MagicMock()})
+        result = op.execute(context={"task_instance": mock.MagicMock()})
         # Verify hook initialization
         mock_hook_class.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -228,7 +228,7 @@ class TestCreateFeatureViewOperator:
             impersonation_chain=IMPERSONATION_CHAIN,
             **common_kwargs,
         )
-        result = op.execute(context={"ti": mock.MagicMock()})
+        result = op.execute(context={"task_instance": mock.MagicMock()})
         # Verify hook initialization
         mock_hook_class.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -280,7 +280,7 @@ class TestFetchFeatureValuesOperator:
             impersonation_chain=IMPERSONATION_CHAIN,
             **common_kwargs,
         )
-        result = op.execute(context={"ti": mock.MagicMock()})
+        result = op.execute(context={"task_instance": mock.MagicMock()})
         # Verify hook initialization
         mock_hook_class.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -326,7 +326,7 @@ class TestGetFeatureOnlineStoreOperator:
             impersonation_chain=IMPERSONATION_CHAIN,
             **common_kwargs,
         )
-        response = op.execute(context={"ti": mock.MagicMock()})
+        response = op.execute(context={"task_instance": mock.MagicMock()})
         # Verify hook initialization
         mock_hook_class.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -362,7 +362,7 @@ class TestDeleteFeatureOnlineStoreOperator:
             impersonation_chain=IMPERSONATION_CHAIN,
             **common_kwargs,
         )
-        response = op.execute(context={"ti": mock.MagicMock()})
+        response = op.execute(context={"task_instance": mock.MagicMock()})
         # Verify hook initialization
         mock_hook_class.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
@@ -398,7 +398,7 @@ class TestDeleteFeatureViewOperator:
             impersonation_chain=IMPERSONATION_CHAIN,
             **common_kwargs,
         )
-        response = op.execute(context={"ti": mock.MagicMock()})
+        response = op.execute(context={"task_instance": mock.MagicMock()})
         # Verify hook initialization
         mock_hook_class.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,

--- a/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_generative_model.py
+++ b/providers/google/tests/unit/google/cloud/operators/vertex_ai/test_generative_model.py
@@ -67,7 +67,7 @@ class TestVertexAITextEmbeddingModelGetEmbeddingsOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -108,7 +108,7 @@ class TestVertexAIGenerativeModelGenerateContentOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -145,7 +145,7 @@ class TestVertexAISupervisedFineTuningTrainOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -179,7 +179,7 @@ class TestVertexAICountTokensOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -258,7 +258,7 @@ class TestVertexAIRunEvaluationOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -313,7 +313,7 @@ class TestVertexAICreateCachedContentOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -344,7 +344,7 @@ class TestVertexAIGenerateFromCachedContentOperator:
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
         )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,
@@ -375,7 +375,7 @@ class TestVertexAIDeleteExperimentRunOperator:
                 gcp_conn_id=GCP_CONN_ID,
                 impersonation_chain=IMPERSONATION_CHAIN,
             )
-        op.execute(context={"ti": mock.MagicMock()})
+        op.execute(context={"task_instance": mock.MagicMock()})
         mock_hook.assert_called_once_with(
             gcp_conn_id=GCP_CONN_ID,
             impersonation_chain=IMPERSONATION_CHAIN,

--- a/providers/google/tests/unit/google/cloud/sensors/test_cloud_storage_transfer_service.py
+++ b/providers/google/tests/unit/google/cloud/sensors/test_cloud_storage_transfer_service.py
@@ -62,7 +62,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor:
             expected_statuses=GcpTransferOperationStatus.SUCCESS,
         )
 
-        context = {"ti": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
+        context = {"task_instance": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
         result = op.poke(context)
 
         mock_tool.return_value.list_transfer_operations.assert_called_once_with(
@@ -96,7 +96,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor:
             expected_statuses=GcpTransferOperationStatus.SUCCESS,
         )
 
-        context = {"ti": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
+        context = {"task_instance": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
         result = op.poke(context)
 
         mock_tool.return_value.list_transfer_operations.assert_called_once_with(
@@ -118,7 +118,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor:
             expected_statuses=GcpTransferOperationStatus.SUCCESS,
         )
 
-        context = {"ti": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
+        context = {"task_instance": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
 
         result = op.poke(context)
 
@@ -162,7 +162,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor:
             expected_statuses=GcpTransferOperationStatus.SUCCESS,
         )
 
-        context = {"ti": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
+        context = {"task_instance": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
 
         result = op.poke(context)
         assert not result
@@ -214,7 +214,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor:
             expected_statuses=expected_status,
         )
 
-        context = {"ti": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
+        context = {"task_instance": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
 
         result = op.poke(context)
         assert not result
@@ -240,7 +240,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor:
         )
 
         mock_hook.operations_contain_expected_statuses.return_value = True
-        context = {"ti": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
+        context = {"task_instance": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
 
         op.execute(context)
         assert not mock_defer.called
@@ -258,7 +258,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor:
         )
 
         mock_hook.operations_contain_expected_statuses.return_value = False
-        context = {"ti": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
+        context = {"task_instance": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
 
         with pytest.raises(TaskDeferred) as exc:
             op.execute(context)
@@ -273,7 +273,7 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor:
             deferrable=True,
         )
 
-        context = {"ti": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
+        context = {"task_instance": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
 
         with pytest.raises(AirflowException):
             op.execute_complete(context=context, event={"status": "error", "message": "test failure message"})
@@ -287,6 +287,6 @@ class TestGcpStorageTransferOperationWaitForJobStatusSensor:
             deferrable=True,
         )
 
-        context = {"ti": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
+        context = {"task_instance": (mock.Mock(**{"xcom_push.return_value": None})), "task": mock.MagicMock()}
 
         op.execute_complete(context=context, event={"status": "success", "operations": []})

--- a/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_local.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_gcs_to_local.py
@@ -63,7 +63,7 @@ class TestGoogleCloudStorageDownloadOperator:
             object_name=TEST_OBJECT,
             store_to_xcom_key=XCOM_KEY,
         )
-        context = {"ti": MagicMock()}
+        context = {"task_instance": MagicMock()}
         mock_hook.return_value.download.return_value = FILE_CONTENT_BYTES_UTF8
         mock_hook.return_value.get_size.return_value = MAX_XCOM_SIZE - 1
 
@@ -74,7 +74,7 @@ class TestGoogleCloudStorageDownloadOperator:
         mock_hook.return_value.download.assert_called_once_with(
             bucket_name=TEST_BUCKET, object_name=TEST_OBJECT
         )
-        context["ti"].xcom_push.assert_called_once_with(key=XCOM_KEY, value=FILE_CONTENT_STR)
+        context["task_instance"].xcom_push.assert_called_once_with(key=XCOM_KEY, value=FILE_CONTENT_STR)
 
     @mock.patch("airflow.providers.google.cloud.transfers.gcs_to_local.GCSHook")
     def test_size_gt_max_xcom_size(self, mock_hook):
@@ -84,7 +84,7 @@ class TestGoogleCloudStorageDownloadOperator:
             object_name=TEST_OBJECT,
             store_to_xcom_key=XCOM_KEY,
         )
-        context = {"ti": MagicMock()}
+        context = {"task_instance": MagicMock()}
         mock_hook.return_value.download.return_value = FILE_CONTENT_BYTES_UTF8
         mock_hook.return_value.get_size.return_value = MAX_XCOM_SIZE + 1
 
@@ -100,7 +100,7 @@ class TestGoogleCloudStorageDownloadOperator:
             store_to_xcom_key=XCOM_KEY,
             file_encoding="utf-16",
         )
-        context = {"ti": MagicMock()}
+        context = {"task_instance": MagicMock()}
         mock_hook.return_value.download.return_value = FILE_CONTENT_BYTES_UTF16
         mock_hook.return_value.get_size.return_value = MAX_XCOM_SIZE - 1
 
@@ -111,7 +111,7 @@ class TestGoogleCloudStorageDownloadOperator:
         mock_hook.return_value.download.assert_called_once_with(
             bucket_name=TEST_BUCKET, object_name=TEST_OBJECT
         )
-        context["ti"].xcom_push.assert_called_once_with(key=XCOM_KEY, value=FILE_CONTENT_STR)
+        context["task_instance"].xcom_push.assert_called_once_with(key=XCOM_KEY, value=FILE_CONTENT_STR)
 
     def test_get_openlineage_facets_on_start_(self):
         operator = GCSToLocalFilesystemOperator(

--- a/providers/google/tests/unit/google/cloud/transfers/test_sheets_to_gcs.py
+++ b/providers/google/tests/unit/google/cloud/transfers/test_sheets_to_gcs.py
@@ -83,7 +83,7 @@ class TestGoogleSheetsToGCSOperator:
     )
     def test_execute(self, mock_upload_data, mock_sheet_hook, mock_gcs_hook):
         mock_ti = mock.MagicMock()
-        mock_context = {"ti": mock_ti}
+        mock_context = {"task_instance": mock_ti}
         data = ["data1", "data2"]
         mock_sheet_hook.return_value.get_sheet_titles.return_value = RANGES
         mock_sheet_hook.return_value.get_values.side_effect = data


### PR DESCRIPTION
This PR unifies setting of Xcom values from `context["ti"]` to `context["task_instance"]`. 
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #ISSUE
related: #ISSUE

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
