### PR TITLE
Fix Enums used in Airflow System Tests that break DAG processor in Airflow 3

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/experiment_service.py
+++ b/providers/google/src/airflow/providers/google/cloud/operators/vertex_ai/experiment_service.py
@@ -327,7 +327,6 @@ class UpdateExperimentRunStateOperator(GoogleCloudBaseOperator):
         "impersonation_chain",
         "experiment_name",
         "experiment_run_name",
-        "new_state",
     )
 
     def __init__(

--- a/providers/google/tests/system/google/cloud/cloud_memorystore/example_cloud_memorystore_redis.py
+++ b/providers/google/tests/system/google/cloud/cloud_memorystore/example_cloud_memorystore_redis.py
@@ -63,17 +63,17 @@ DAG_ID = "cloud_memorystore_redis"
 
 BUCKET_NAME = f"bucket_{DAG_ID}_{ENV_ID}"
 LOCATION = "europe-north1"
-MEMORYSTORE_REDIS_INSTANCE_NAME = f"redis-{ENV_ID_LOWER}-1"
-MEMORYSTORE_REDIS_INSTANCE_NAME_2 = f"redis-{ENV_ID_LOWER}-2"
-MEMORYSTORE_REDIS_INSTANCE_NAME_3 = f"redis-{ENV_ID_LOWER}-3"
+MEMORYSTORE_REDIS_INSTANCE_NAME = f"redis-{ENV_ID_LOWER}-1".replace("_", "-")
+MEMORYSTORE_REDIS_INSTANCE_NAME_2 = f"redis-{ENV_ID_LOWER}-2".replace("_", "-")
+MEMORYSTORE_REDIS_INSTANCE_NAME_3 = f"redis-{ENV_ID_LOWER}-3".replace("_", "-")
 
 EXPORT_GCS_URL = f"gs://{BUCKET_NAME}/my-export.rdb"
 
 # [START howto_operator_instance]
-FIRST_INSTANCE = {"tier": Instance.Tier.BASIC, "memory_size_gb": 1}
+FIRST_INSTANCE = {"tier": Instance.Tier.BASIC.value, "memory_size_gb": 1}  # type: ignore[attr-defined]
 # [END howto_operator_instance]
 
-SECOND_INSTANCE = {"tier": Instance.Tier.STANDARD_HA, "memory_size_gb": 3}
+SECOND_INSTANCE = {"tier": Instance.Tier.STANDARD_HA.value, "memory_size_gb": 3}  # type: ignore[attr-defined]
 
 
 with DAG(
@@ -134,7 +134,7 @@ with DAG(
         location=LOCATION,
         instance=MEMORYSTORE_REDIS_INSTANCE_NAME_2,
         data_protection_mode=FailoverInstanceRequest.DataProtectionMode(
-            FailoverInstanceRequest.DataProtectionMode.LIMITED_DATA_LOSS
+            FailoverInstanceRequest.DataProtectionMode.LIMITED_DATA_LOSS.value  # type: ignore[attr-defined]
         ),
         project_id=PROJECT_ID,
     )

--- a/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_experiment_service.py
+++ b/providers/google/tests/system/google/cloud/vertex_ai/example_vertex_ai_experiment_service.py
@@ -36,9 +36,9 @@ ENV_ID = os.environ.get("SYSTEM_TESTS_ENV_ID", "default")
 PROJECT_ID = os.environ.get("SYSTEM_TESTS_GCP_PROJECT", "default")
 DAG_ID = "vertex_ai_experiment_service_dag"
 REGION = "us-central1"
-EXPERIMENT_NAME = f"test-experiment-airflow-operator-{ENV_ID}"
-EXPERIMENT_RUN_NAME_1 = f"test-experiment-run-airflow-operator-1-{ENV_ID}"
-EXPERIMENT_RUN_NAME_2 = f"test-experiment-run-airflow-operator-2-{ENV_ID}"
+EXPERIMENT_NAME = f"test-experiment-airflow-operator-{ENV_ID}".replace("_", "-")
+EXPERIMENT_RUN_NAME_1 = f"test-experiment-run-airflow-operator-1-{ENV_ID}".replace("_", "-")
+EXPERIMENT_RUN_NAME_2 = f"test-experiment-run-airflow-operator-2-{ENV_ID}".replace("_", "-")
 
 with DAG(
     dag_id=DAG_ID,

--- a/providers/google/tests/system/google/cloud/vision/example_vision_annotate_image.py
+++ b/providers/google/tests/system/google/cloud/vision/example_vision_annotate_image.py
@@ -65,7 +65,7 @@ GCP_VISION_ANNOTATE_IMAGE_URL = f"gs://{BUCKET_NAME}/{FILE_NAME}"
 # [START howto_operator_vision_annotate_image_request]
 annotate_image_request = {
     "image": {"source": {"image_uri": GCP_VISION_ANNOTATE_IMAGE_URL}},
-    "features": [{"type_": Feature.Type.LOGO_DETECTION}],
+    "features": [{"type_": Feature.Type.LOGO_DETECTION.value}],  # type: ignore[attr-defined]
 }
 # [END howto_operator_vision_annotate_image_request]
 

--- a/providers/google/tests/system/google/marketing_platform/example_analytics_admin.py
+++ b/providers/google/tests/system/google/marketing_platform/example_analytics_admin.py
@@ -149,7 +149,7 @@ with DAG(
             "web_stream_data": {
                 "default_uri": "www.example.com",
             },
-            "type_": google_analytics.DataStream.DataStreamType.WEB_DATA_STREAM,
+            "type_": google_analytics.DataStream.DataStreamType.WEB_DATA_STREAM.value,  # type: ignore[attr-defined]
         },
         gcp_conn_id=CONNECTION_ID,
     )


### PR DESCRIPTION
The following System Tests are not properly parsed by DAG processor in Airflow 3.1.0:
- cloud_memorystore_redis
- google_analytics_admin
- vertex_ai_experiment_service_dag
- gcp_vision_annotate_image

Exception from the logs of DAG processor:
`dag-processor-manager Traceback (most recent call last):
  File "/opt/python3.11/lib/python3.11/site-packages/airflow/sdk/execution_time/supervisor.py", line 387, in _fork_main
    target()
  File "/opt/python3.11/lib/python3.11/site-packages/airflow/dag_processing/processor.py", line 187, in _parse_file_entrypoint
    comms_decoder.send(result)
  File "/opt/python3.11/lib/python3.11/site-packages/airflow/sdk/execution_time/comms.py", line 190, in send
    frame_bytes = frame.as_bytes()
                  ^^^^^^^^^^^^^^^^
  File "/opt/python3.11/lib/python3.11/site-packages/airflow/sdk/execution_time/comms.py", line 148, in as_bytes
    self.req_encoder.encode_into(self, buffer, 4)
  File "/opt/python3.11/lib/python3.11/site-packages/airflow/sdk/execution_time/comms.py", line 125, in _msgpack_enc_hook
    raise NotImplementedError(f"Objects of type {type(obj)} are not supported")
NotImplementedError: Objects of type <enum 'Type'> are not supported`

Right after release of Airflow 3.0.0 we saw the same error but when passing values from worker to trigger and back. The issue was created and decision in the Community is to adjust code for the current serialization, because adding custom serializers for every provider will take a lot of time - there bunch of different types and we can't cover all of them -> https://github.com/apache/airflow/issues/54781.   

New way of serialization was added in Airflow 3.1.0 that throws this error for dags that contain Enums and other non-serializiable objects:
https://github.com/apache/airflow/pull/51699/files#diff-c076ff9d88eb776c2f874ea4fbb66c9d090e080ed5c9b80c2c36dcb3a51360d3R100 
The error is not visible until deeper check of the logs of dag-processor, because the dag is just excluded from the run and not visible on UI.

Solution:
In this PR I have replaced the direct usage of Enum to use the value of it. In one of the cases there was a problem to add this in create_experiment() method of CreateExperimentOperator, since in the API side method accepts only Enum as a parameter, so this field was just removed from templated_fields to fix the error.

Another idea here is to add some check to verify if the parameter added to templated_fields can be serialized at all, so people will not put all the possible parameters existed in the operator to templated_fields. 
While I understand that there are for sure cases where some objects that are not easily serialized should be added to templated_fields (for example, Instance object that describes an object to be created in some operator), the solution here is:
1) prevent adding EVERYTHING possible to templated_fields that can't be serialized properly
2) if you still need to pass this kind of objects to templated_fields, make sure you pass '.value' value of that object

@potiuk Can you please check what do you think about my approach? :)
<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).
