### PR TITLE
Openlineage: read API key auth from Airflow connection

### DIFF
--- a/providers/openlineage/docs/configurations-ref.rst
+++ b/providers/openlineage/docs/configurations-ref.rst
@@ -56,6 +56,24 @@ If you want to look at OpenLineage events without sending them anywhere, you can
     [openlineage]
     transport = {"type": "console"}
 
+HTTP transport with an API key stored in an Airflow connection
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+For HTTP transports that require API key authentication, you can keep the token in an Airflow connection instead of
+putting the secret directly in Airflow configuration. Create an Airflow connection, store the API key in the
+connection password, and set ``auth.type`` to ``airflow_connection_api_key`` with ``conn_id`` pointing to that
+connection.
+The provider resolves ``airflow_connection_api_key`` to standard OpenLineage ``api_key`` auth before creating the
+OpenLineage client.
+
+.. code-block:: json
+
+    {
+      "type": "http",
+      "url": "http://example.com:5000",
+      "auth": {"type": "airflow_connection_api_key", "conn_id": "openlineage_default"}
+    }
+
 .. note::
   For full list of built-in transport types, specific transport's options or instructions on how to implement your custom transport, refer to
   `Python client documentation <https://openlineage.io/docs/client/python/configuration#transports>`_.

--- a/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/plugins/adapter.py
@@ -35,6 +35,10 @@ from openlineage.client.facet_v2 import (
 )
 
 from airflow.providers.common.compat.sdk import Stats, conf as airflow_conf
+from airflow.providers.openlineage.token_provider import (
+    AIRFLOW_CONNECTION_API_KEY_AUTH_TYPE,
+    AirflowConnectionTokenProvider,
+)
 from airflow.providers.openlineage import conf
 from airflow.providers.openlineage.utils.utils import (
     _PRODUCER,
@@ -107,6 +111,9 @@ class OpenLineageAdapter(LoggingMixin):
         openlineage_config_path = conf.config_path(check_legacy_env_var=False)
         if openlineage_config_path:
             config = self._read_yaml_config(openlineage_config_path)
+            if config is None:
+                return None
+            self._resolve_airflow_connection_auth(config.get("transport"))
             return config
         self.log.debug("OpenLineage config_path configuration not found.")
 
@@ -115,12 +122,24 @@ class OpenLineageAdapter(LoggingMixin):
         if not transport_config:
             self.log.debug("OpenLineage transport configuration not found.")
             return None
-        return {"transport": transport_config}
+        config = {"transport": transport_config}
+        self._resolve_airflow_connection_auth(transport_config)
+        return config
 
     @staticmethod
     def _read_yaml_config(path: str) -> dict | None:
         with open(path) as config_file:
             return yaml.safe_load(config_file)
+
+    @staticmethod
+    def _resolve_airflow_connection_auth(transport_config: dict | None) -> None:
+        if not isinstance(transport_config, dict):
+            return
+
+        auth = transport_config.get("auth")
+        if isinstance(auth, dict) and auth.get("type") == AIRFLOW_CONNECTION_API_KEY_AUTH_TYPE:
+            provider = AirflowConnectionTokenProvider(auth)
+            transport_config["auth"] = {"type": "api_key", "apiKey": provider.get_api_key()}
 
     @staticmethod
     def build_dag_run_id(dag_id: str, logical_date: datetime, clear_number: int) -> str:

--- a/providers/openlineage/src/airflow/providers/openlineage/token_provider.py
+++ b/providers/openlineage/src/airflow/providers/openlineage/token_provider.py
@@ -1,0 +1,69 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from typing import Any
+
+from airflow.providers.common.compat.sdk import AirflowException, BaseHook
+
+AIRFLOW_CONNECTION_API_KEY_AUTH_TYPE = "airflow_connection_api_key"
+_DEFAULT_EXTRA_KEYS = ("apiKey", "api_key", "apikey", "token", "access_token")
+
+
+class OpenLineageAirflowConnectionAuthError(AirflowException):
+    """Raised when OpenLineage API key auth cannot be resolved from an Airflow connection."""
+
+
+class AirflowConnectionTokenProvider:
+    """
+    Resolve an OpenLineage API key from an Airflow connection.
+
+    The connection password is preferred. If it is empty and ``extra_key`` is configured, that key
+    is read from connection ``extra``. Otherwise, common extra keys are checked.
+    """
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        self.conn_id = config.get("conn_id", "")
+        self.extra_key = config.get("extra_key")
+        if not self.conn_id:
+            raise OpenLineageAirflowConnectionAuthError(
+                "OpenLineage `airflow_connection_api_key` auth requires a non-empty `conn_id`."
+            )
+
+    def get_api_key(self) -> str:
+        connection = BaseHook.get_connection(self.conn_id)
+        if connection.password:
+            return connection.password.strip()
+        api_key = self._get_api_key_from_extra(connection.extra_dejson)
+        if api_key:
+            return api_key
+
+        raise OpenLineageAirflowConnectionAuthError(
+            "OpenLineage `airflow_connection_api_key` auth could not find a token in connection "
+            f"`{self.conn_id}`. Expected connection password or token in connection extra."
+        )
+
+    def _get_api_key_from_extra(self, extra: dict[str, Any]) -> str | None:
+        if self.extra_key:
+            value = extra.get(self.extra_key)
+            return str(value).strip() if value else None
+
+        for key in _DEFAULT_EXTRA_KEYS:
+            value = extra.get(key)
+            if value:
+                return str(value).strip()
+        return None

--- a/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
+++ b/providers/openlineage/tests/unit/openlineage/plugins/test_adapter.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 import os
 import pathlib
 import uuid
@@ -41,7 +42,7 @@ from openlineage.client.facet_v2 import (
 from airflow import DAG
 from airflow.models.dagrun import DagRun, DagRunState
 from airflow.models.taskinstance import TaskInstance, TaskInstanceState
-from airflow.providers.common.compat.sdk import Stats
+from airflow.providers.common.compat.sdk import BaseHook, Connection, Stats
 from airflow.providers.openlineage.conf import namespace
 from airflow.providers.openlineage.extractors import OperatorLineage
 from airflow.providers.openlineage.plugins.adapter import _PRODUCER, OpenLineageAdapter
@@ -49,6 +50,10 @@ from airflow.providers.openlineage.plugins.facets import (
     AirflowDagRunFacet,
     AirflowDebugRunFacet,
     AirflowStateRunFacet,
+)
+from airflow.providers.openlineage.token_provider import (
+    AIRFLOW_CONNECTION_API_KEY_AUTH_TYPE,
+    OpenLineageAirflowConnectionAuthError,
 )
 from airflow.providers.openlineage.utils.utils import get_airflow_job_facet
 from airflow.providers.standard.operators.empty import EmptyOperator
@@ -100,6 +105,69 @@ def test_create_client_from_config_with_options():
 
     assert client.transport.kind == "http"
     assert client.transport.url == "http://ol-api:5000"
+
+
+def _connection_auth_transport_config(**auth_config):
+    auth = {
+        "type": AIRFLOW_CONNECTION_API_KEY_AUTH_TYPE,
+        "conn_id": "openlineage_default",
+        **auth_config,
+    }
+    return json.dumps({"type": "http", "url": "http://ol-api:5000", "auth": auth})
+
+
+@patch.object(BaseHook, "get_connection")
+def test_create_client_from_config_with_connection_auth_password(mock_get_connection):
+    mock_get_connection.return_value = Connection(
+        conn_id="openlineage_default", conn_type="http", password="api-key"
+    )
+
+    with conf_vars({("openlineage", "transport"): _connection_auth_transport_config()}):
+        client = OpenLineageAdapter().get_or_create_openlineage_client()
+
+    assert client.transport.kind == "http"
+    assert client.transport.url == "http://ol-api:5000"
+    assert client.transport.config.auth.api_key == "api-key"
+
+
+@patch.object(BaseHook, "get_connection")
+def test_create_client_from_config_with_connection_auth_extra(mock_get_connection):
+    mock_get_connection.return_value = Connection(
+        conn_id="openlineage_default",
+        conn_type="http",
+        extra='{"lineage_token": "api-key-from-extra"}',
+    )
+
+    transport_config = _connection_auth_transport_config(extra_key="lineage_token")
+    with conf_vars({("openlineage", "transport"): transport_config}):
+        client = OpenLineageAdapter().get_or_create_openlineage_client()
+
+    assert client.transport.kind == "http"
+    assert client.transport.config.auth.api_key == "api-key-from-extra"
+
+
+@patch.object(BaseHook, "get_connection")
+def test_create_client_from_config_with_connection_auth_token_extra(mock_get_connection):
+    mock_get_connection.return_value = Connection(
+        conn_id="openlineage_default",
+        conn_type="http",
+        extra='{"token": "api-key-from-token"}',
+    )
+
+    with conf_vars({("openlineage", "transport"): _connection_auth_transport_config()}):
+        client = OpenLineageAdapter().get_or_create_openlineage_client()
+
+    assert client.transport.kind == "http"
+    assert client.transport.config.auth.api_key == "api-key-from-token"
+
+
+@patch.object(BaseHook, "get_connection")
+def test_create_client_from_config_with_connection_auth_missing_secret(mock_get_connection):
+    mock_get_connection.return_value = Connection(conn_id="openlineage_default", conn_type="http", extra="{}")
+
+    with conf_vars({("openlineage", "transport"): _connection_auth_transport_config()}):
+        with pytest.raises(OpenLineageAirflowConnectionAuthError, match="could not find a token"):
+            OpenLineageAdapter().get_or_create_openlineage_client()
 
 
 def test_create_client_from_yaml_config():

--- a/providers/openlineage/tests/unit/openlineage/test_token_provider.py
+++ b/providers/openlineage/tests/unit/openlineage/test_token_provider.py
@@ -1,0 +1,65 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from airflow.providers.common.compat.sdk import BaseHook, Connection
+from airflow.providers.openlineage.token_provider import (
+    AirflowConnectionTokenProvider,
+    OpenLineageAirflowConnectionAuthError,
+)
+
+
+@patch.object(BaseHook, "get_connection")
+def test_get_api_key_from_connection_password(mock_get_connection):
+    mock_get_connection.return_value = Connection(
+        conn_id="openlineage_default", conn_type="http", password="api-key"
+    )
+
+    provider = AirflowConnectionTokenProvider({"conn_id": "openlineage_default"})
+
+    assert provider.get_api_key() == "api-key"
+
+
+@patch.object(BaseHook, "get_connection")
+def test_get_api_key_from_connection_extra(mock_get_connection):
+    mock_get_connection.return_value = Connection(
+        conn_id="openlineage_default", conn_type="http", extra='{"api_key": "api-key-from-extra"}'
+    )
+
+    provider = AirflowConnectionTokenProvider({"conn_id": "openlineage_default"})
+
+    assert provider.get_api_key() == "api-key-from-extra"
+
+
+def test_missing_conn_id_raises_custom_exception():
+    with pytest.raises(OpenLineageAirflowConnectionAuthError, match="requires a non-empty `conn_id`"):
+        AirflowConnectionTokenProvider({})
+
+
+@patch.object(BaseHook, "get_connection")
+def test_missing_token_raises_custom_exception(mock_get_connection):
+    mock_get_connection.return_value = Connection(conn_id="openlineage_default", conn_type="http")
+
+    provider = AirflowConnectionTokenProvider({"conn_id": "openlineage_default"})
+
+    with pytest.raises(OpenLineageAirflowConnectionAuthError, match="could not find a token"):
+        provider.get_api_key()


### PR DESCRIPTION
Adds OpenLineage HTTP API key authentication from Airflow connection.

Users now can configure connection like this:
{"type":"http","url":"https://openlineage.example.com","auth":{"type":"airflow_connection_api_key","conn_id":"openlineage_default"}}

The token now is read from the connection password, or from connection extra keys such as apiKey, api_key, token, or access_token. This token is used in constructing new valid connection under the hood.

This option will help creating connections without exposing tokens in Airflow connection configs.

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
