### PR TITLE
Fix DataprocCreateBatchOperator stuck in deferred state for a long time

### DIFF
--- a/providers/google/src/airflow/providers/google/cloud/hooks/dataproc.py
+++ b/providers/google/src/airflow/providers/google/cloud/hooks/dataproc.py
@@ -1297,6 +1297,7 @@ class DataprocAsyncHook(GoogleBaseAsyncHook):
     ) -> None:
         super().__init__(gcp_conn_id=gcp_conn_id, impersonation_chain=impersonation_chain, **kwargs)
         self._cached_client: JobControllerAsyncClient | None = None
+        self._cached_batch_client: BatchControllerAsyncClient | None = None
 
     async def get_cluster_client(self, region: str | None = None) -> ClusterControllerAsyncClient:
         """Create a ClusterControllerAsyncClient."""
@@ -1338,15 +1339,17 @@ class DataprocAsyncHook(GoogleBaseAsyncHook):
 
     async def get_batch_client(self, region: str | None = None) -> BatchControllerAsyncClient:
         """Create a BatchControllerAsyncClient."""
-        sync_hook = await self.get_sync_hook()
+        if self._cached_batch_client is None:
+            sync_hook = await self.get_sync_hook()
 
-        return BatchControllerAsyncClient(
-            credentials=sync_hook.get_credentials(),
-            client_info=CLIENT_INFO,
-            client_options=sync_hook.get_client_options(
-                api_endpoint_override=sync_hook._get_api_endpoint(region=region)
-            ),
-        )
+            self._cached_batch_client = BatchControllerAsyncClient(
+                credentials=sync_hook.get_credentials(),
+                client_info=CLIENT_INFO,
+                client_options=sync_hook.get_client_options(
+                    api_endpoint_override=sync_hook._get_api_endpoint(region=region)
+                ),
+            )
+        return self._cached_batch_client
 
     async def get_operations_client(self, region: str) -> OperationsClient:
         """Create a OperationsClient."""

--- a/providers/google/src/airflow/providers/google/cloud/triggers/dataproc.py
+++ b/providers/google/src/airflow/providers/google/cloud/triggers/dataproc.py
@@ -594,8 +594,11 @@ class DataprocBatchTrigger(DataprocBaseTrigger):
         )
 
     async def run(self):
+        hook = self.get_async_hook()
+        await hook.get_batch_client(region=self.region)
+
         while True:
-            batch = await self.get_async_hook().get_batch(
+            batch = await hook.get_batch(
                 project_id=self.project_id, region=self.region, batch_id=self.batch_id
             )
             state = batch.state

--- a/providers/google/tests/unit/google/cloud/triggers/test_dataproc.py
+++ b/providers/google/tests/unit/google/cloud/triggers/test_dataproc.py
@@ -413,6 +413,7 @@ class TestDataprocBatchTrigger:
 
         future = asyncio.Future()
         future.set_result(mock_batch)
+        mock_get_async_hook.return_value.get_batch_client = mock.AsyncMock()
         mock_get_async_hook.return_value.get_batch.return_value = future
 
         expected_event = TriggerEvent(
@@ -439,6 +440,7 @@ class TestDataprocBatchTrigger:
 
         future = asyncio.Future()
         future.set_result(mock_batch)
+        mock_get_async_hook.return_value.get_batch_client = mock.AsyncMock()
         mock_get_async_hook.return_value.get_batch.return_value = future
 
         expected_event = TriggerEvent(
@@ -463,6 +465,7 @@ class TestDataprocBatchTrigger:
 
         future = asyncio.Future()
         future.set_result(mock_batch)
+        mock_get_async_hook.return_value.get_batch_client = mock.AsyncMock()
         mock_get_async_hook.return_value.get_batch.return_value = future
 
         expected_event = TriggerEvent(
@@ -487,6 +490,7 @@ class TestDataprocBatchTrigger:
 
         future = asyncio.Future()
         future.set_result(mock_batch)
+        mock_get_async_hook.return_value.get_batch_client = mock.AsyncMock()
         mock_get_async_hook.return_value.get_batch.return_value = future
 
         task = asyncio.create_task(batch_trigger.run().__anext__())
@@ -494,6 +498,38 @@ class TestDataprocBatchTrigger:
 
         assert not task.done()
         mock_log.info.assert_called()
+
+    @pytest.mark.db_test
+    @pytest.mark.asyncio
+    @mock.patch("airflow.providers.google.cloud.triggers.dataproc.DataprocBatchTrigger.get_async_hook")
+    @mock.patch("airflow.providers.google.cloud.triggers.dataproc.asyncio.sleep", new_callable=mock.AsyncMock)
+    async def test_create_batch_trigger_initializes_batch_client_once(
+        self, mock_sleep, mock_get_async_hook, batch_trigger
+    ):
+        running_batch = mock.MagicMock()
+        running_batch.state = Batch.State.RUNNING
+        running_batch.state_message = TEST_BATCH_STATE_MESSAGE
+        succeeded_batch = mock.MagicMock()
+        succeeded_batch.state = Batch.State.SUCCEEDED
+        succeeded_batch.state_message = TEST_BATCH_STATE_MESSAGE
+
+        mock_get_async_hook.return_value.get_batch_client = mock.AsyncMock()
+        mock_get_async_hook.return_value.get_batch = mock.AsyncMock(
+            side_effect=[running_batch, succeeded_batch]
+        )
+
+        actual_event = await batch_trigger.run().asend(None)
+
+        assert actual_event == TriggerEvent(
+            {
+                "batch_id": TEST_BATCH_ID,
+                "batch_state": Batch.State.SUCCEEDED.name,
+                "batch_state_message": TEST_BATCH_STATE_MESSAGE,
+            }
+        )
+        mock_get_async_hook.return_value.get_batch_client.assert_awaited_once_with(region=TEST_REGION)
+        assert mock_get_async_hook.return_value.get_batch.await_count == 2
+        mock_sleep.assert_awaited_once_with(TEST_POLL_INTERVAL)
 
 
 class TestDataprocOperationTrigger:


### PR DESCRIPTION
Fixes `DataprocBatchTrigger` so it reuses a single Dataproc batch async client while polling batch state.
`DataprocCreateBatchOperator` can remain stuck in deferred state even after the Dataproc batch has completed successfully.

This is similar to the issue recently fixed for `DataprocSubmitJobOperator`: https://github.com/apache/airflow/pull/62082
 

<!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
