### PR TITLE
Displaying first_name+last_name or email in "Audit Log" on DAG details page

### DIFF
--- a/airflow-core/src/airflow/api_fastapi/core_api/datamodels/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/datamodels/event_logs.py
@@ -38,6 +38,7 @@ class EventLogResponse(BaseModel):
     event: str
     logical_date: datetime | None
     owner: str | None
+    owner_display_name: str | None
     extra: str | None
     dag_display_name: str | None = Field(
         validation_alias=AliasPath("dag_model", "dag_display_name"), default=None

--- a/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
+++ b/airflow-core/src/airflow/api_fastapi/core_api/openapi/v2-rest-api-generated.yaml
@@ -4462,13 +4462,15 @@ paths:
             type: string
           description: 'Attributes to order by, multi criteria sort is supported.
             Prefix with `-` for descending order. Supported attributes: `id, dttm,
-            dag_id, task_id, run_id, event, logical_date, owner, extra, when, event_log_id`'
+            dag_id, task_id, run_id, event, logical_date, owner, owner_display_name,
+            extra, when, event_log_id`'
           default:
           - id
           title: Order By
         description: 'Attributes to order by, multi criteria sort is supported. Prefix
           with `-` for descending order. Supported attributes: `id, dttm, dag_id,
-          task_id, run_id, event, logical_date, owner, extra, when, event_log_id`'
+          task_id, run_id, event, logical_date, owner, owner_display_name, extra,
+          when, event_log_id`'
       - name: dag_id
         in: query
         required: false
@@ -14364,6 +14366,11 @@ components:
           - type: string
           - type: 'null'
           title: Owner
+        owner_display_name:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Owner Display Name
         extra:
           anyOf:
           - type: string
@@ -14391,6 +14398,7 @@ components:
       - event
       - logical_date
       - owner
+      - owner_display_name
       - extra
       title: EventLogResponse
       description: Event Log Response.

--- a/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
+++ b/airflow-core/src/airflow/api_fastapi/core_api/routes/public/event_logs.py
@@ -100,6 +100,7 @@ def get_event_logs(
                     "event",
                     "logical_date",
                     "owner",
+                    "owner_display_name",
                     "extra",
                 ],
                 Log,

--- a/airflow-core/src/airflow/api_fastapi/logging/decorators.py
+++ b/airflow-core/src/airflow/api_fastapi/logging/decorators.py
@@ -45,6 +45,20 @@ def _sanitize_for_stdlib_log(value: str) -> str:
     return value.replace("\r", " ").replace("\n", " ")
 
 
+def _get_user_display_name(user) -> str:
+    """Return the most readable identity label available for audit logs."""
+    first_name = (getattr(user, "first_name", None) or "").strip()
+    last_name = (getattr(user, "last_name", None) or "").strip()
+    email = (getattr(user, "email", None) or "").strip()
+    username = user.get_name()
+
+    if first_name and last_name and last_name != "-":
+        return f"{first_name} {last_name}"
+    if email:
+        return email
+    return username
+
+
 def _mask_connection_fields(extra_fields):
     """Mask connection fields."""
     result = {}
@@ -98,7 +112,7 @@ def action_logging(event: str | None = None):
             user_display = ""
         else:
             user_name = user.get_name()
-            user_display = user.get_name()
+            user_display = _get_user_display_name(user)
 
         has_json_body = "application/json" in request.headers.get("content-type", "") and await request.body()
         request_body = {}

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/ensureQueryData.ts
@@ -724,7 +724,7 @@ export const ensureUseEventLogServiceGetEventLogData = (queryClient: QueryClient
 * @param data The data for the request.
 * @param data.limit
 * @param data.offset
-* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, extra, when, event_log_id`
+* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, owner_display_name, extra, when, event_log_id`
 * @param data.dagId
 * @param data.taskId
 * @param data.runId

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/prefetch.ts
@@ -724,7 +724,7 @@ export const prefetchUseEventLogServiceGetEventLog = (queryClient: QueryClient, 
 * @param data The data for the request.
 * @param data.limit
 * @param data.offset
-* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, extra, when, event_log_id`
+* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, owner_display_name, extra, when, event_log_id`
 * @param data.dagId
 * @param data.taskId
 * @param data.runId

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/queries.ts
@@ -724,7 +724,7 @@ export const useEventLogServiceGetEventLog = <TData = Common.EventLogServiceGetE
 * @param data The data for the request.
 * @param data.limit
 * @param data.offset
-* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, extra, when, event_log_id`
+* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, owner_display_name, extra, when, event_log_id`
 * @param data.dagId
 * @param data.taskId
 * @param data.runId

--- a/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/queries/suspense.ts
@@ -724,7 +724,7 @@ export const useEventLogServiceGetEventLogSuspense = <TData = Common.EventLogSer
 * @param data The data for the request.
 * @param data.limit
 * @param data.offset
-* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, extra, when, event_log_id`
+* @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, owner_display_name, extra, when, event_log_id`
 * @param data.dagId
 * @param data.taskId
 * @param data.runId

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/schemas.gen.ts
@@ -4428,6 +4428,17 @@ export const $EventLogResponse = {
             ],
             title: 'Owner'
         },
+        owner_display_name: {
+            anyOf: [
+                {
+                    type: 'string'
+                },
+                {
+                    type: 'null'
+                }
+            ],
+            title: 'Owner Display Name'
+        },
         extra: {
             anyOf: [
                 {
@@ -4463,7 +4474,7 @@ export const $EventLogResponse = {
         }
     },
     type: 'object',
-    required: ['event_log_id', 'when', 'dag_id', 'task_id', 'run_id', 'map_index', 'try_number', 'event', 'logical_date', 'owner', 'extra'],
+    required: ['event_log_id', 'when', 'dag_id', 'task_id', 'run_id', 'map_index', 'try_number', 'event', 'logical_date', 'owner', 'owner_display_name', 'extra'],
     title: 'EventLogResponse',
     description: 'Event Log Response.'
 } as const;

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/services.gen.ts
@@ -1991,7 +1991,7 @@ export class EventLogService {
      * @param data The data for the request.
      * @param data.limit
      * @param data.offset
-     * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, extra, when, event_log_id`
+     * @param data.orderBy Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, owner_display_name, extra, when, event_log_id`
      * @param data.dagId
      * @param data.taskId
      * @param data.runId

--- a/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
+++ b/airflow-core/src/airflow/ui/openapi-gen/requests/types.gen.ts
@@ -1147,6 +1147,7 @@ export type EventLogResponse = {
     event: string;
     logical_date: string | null;
     owner: string | null;
+    owner_display_name: string | null;
     extra: string | null;
     dag_display_name?: string | null;
     task_display_name?: string | null;
@@ -3410,7 +3411,7 @@ export type GetEventLogsData = {
     mapIndex?: number | null;
     offset?: number;
     /**
-     * Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, extra, when, event_log_id`
+     * Attributes to order by, multi criteria sort is supported. Prefix with `-` for descending order. Supported attributes: `id, dttm, dag_id, task_id, run_id, event, logical_date, owner, owner_display_name, extra, when, event_log_id`
      */
     orderBy?: Array<(string)>;
     owner?: string | null;

--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/browse.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/browse.json
@@ -4,6 +4,7 @@
       "event": "Event",
       "extra": "Extra",
       "user": "User",
+      "userDisplayName": "User Display Name",
       "when": "When"
     },
     "filters": {

--- a/airflow-core/src/airflow/ui/src/pages/Events/Events.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/Events/Events.tsx
@@ -72,6 +72,15 @@ const eventsColumn = (
     },
   },
   {
+    accessorKey: "owner_display_name",
+    cell: ({ row: { original } }) => original.owner_display_name?.replace(/ -$/u, ""),
+    enableSorting: true,
+    header: translate("auditLog.columns.userDisplayName"),
+    meta: {
+      skeletonWidth: 10,
+    },
+  },
+  {
     accessorKey: "extra",
     cell: ({ row: { original } }) => {
       if (original.extra !== null) {

--- a/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
+++ b/airflow-core/tests/unit/api_fastapi/core_api/routes/public/test_event_logs.py
@@ -128,6 +128,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
                 {
                     "event": EVENT_WITH_OWNER,
                     "owner": OWNER,
+                    "owner_display_name": OWNER_DISPLAY_NAME,
                 },
             ),
             (
@@ -153,6 +154,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
                     "event": EVENT_WITH_OWNER_AND_TASK_INSTANCE,
                     "map_index": -1,
                     "owner": OWNER,
+                    "owner_display_name": OWNER_DISPLAY_NAME,
                     "run_id": DAG_RUN_ID,
                     "task_id": TASK_ID,
                     "task_display_name": TASK_DISPLAY_NAME,
@@ -185,6 +187,7 @@ class TestGetEventLog(TestEventLogsEndpoint):
             if event_log.logical_date
             else None,
             "owner": expected_body.get("owner"),
+            "owner_display_name": expected_body.get("owner_display_name"),
             "extra": expected_body.get("extra"),
         }
 
@@ -384,6 +387,14 @@ class TestGetEventLogs(TestEventLogsEndpoint):
         resp_json = response.json()
         assert resp_json["total_entries"] == 4
         assert EVENT_WITHOUT_DTTM not in {event_log["event"] for event_log in resp_json["event_logs"]}
+
+    def test_get_event_logs_includes_owner_display_name(self, test_client):
+        response = test_client.get("/eventLogs", params={"event": EVENT_WITH_OWNER})
+        assert response.status_code == 200
+
+        event_log = response.json()["event_logs"][0]
+        assert event_log["owner"] == OWNER
+        assert event_log["owner_display_name"] == OWNER_DISPLAY_NAME
 
     # Ordering of nulls values is DB specific.
     @pytest.mark.backend("sqlite")

--- a/airflow-core/tests/unit/api_fastapi/logging/test_decorators.py
+++ b/airflow-core/tests/unit/api_fastapi/logging/test_decorators.py
@@ -21,10 +21,22 @@ import json
 import pytest
 
 from airflow.api_fastapi.logging.decorators import (
+    _get_user_display_name,
     _mask_connection_fields,
     _mask_variable_fields,
     _sanitize_for_stdlib_log,
 )
+
+
+class User:
+    def __init__(self, username, first_name=None, last_name=None, email=None):
+        self.username = username
+        self.first_name = first_name
+        self.last_name = last_name
+        self.email = email
+
+    def get_name(self):
+        return self.username
 
 
 class TestSanitizeForStdlibLog:
@@ -122,3 +134,33 @@ class TestMaskVariableFields:
     def test_value_without_key_is_still_masked(self):
         result = _mask_variable_fields({"value": "secretval"})
         assert result == {"value": "***"}
+
+
+@pytest.mark.parametrize(
+    ("user", "expected_display_name"),
+    [
+        pytest.param(User(username="jane"), "jane", id="username-only"),
+        pytest.param(
+            User(username="jane", first_name="Jane", last_name="Smith", email="jane@example.com"),
+            "Jane Smith",
+            id="first-and-last-name",
+        ),
+        pytest.param(
+            User(username="jane", first_name="", last_name="", email="jane@example.com"),
+            "jane@example.com",
+            id="email",
+        ),
+        pytest.param(
+            User(
+                username="accounts.google.com:123456789",
+                first_name="jane@example.com",
+                last_name="-",
+                email="jane@example.com",
+            ),
+            "jane@example.com",
+            id="composer-email-placeholder-last-name",
+        ),
+    ],
+)
+def test_get_user_display_name(user, expected_display_name):
+    assert _get_user_display_name(user) == expected_display_name

--- a/airflow-ctl/src/airflowctl/api/datamodels/generated.py
+++ b/airflow-ctl/src/airflowctl/api/datamodels/generated.py
@@ -582,6 +582,7 @@ class EventLogResponse(BaseModel):
     event: Annotated[str, Field(title="Event")]
     logical_date: Annotated[datetime | None, Field(title="Logical Date")] = None
     owner: Annotated[str | None, Field(title="Owner")] = None
+    owner_display_name: Annotated[str | None, Field(title="Owner Display Name")] = None
     extra: Annotated[str | None, Field(title="Extra")] = None
     dag_display_name: Annotated[str | None, Field(title="Dag Display Name")] = None
     task_display_name: Annotated[str | None, Field(title="Task Display Name")] = None


### PR DESCRIPTION
In Breeze / community Airflow, there are several types of auth managers that have different sets of fields, which actually leads to different data stored to DB about the user.
The default auth manager is usually SimpleAuthManager. It only knows simple login data like:
- username
- role
- password

For example:
username: admin
role: admin
password: admin

So in default Breeze, the new column will look the same as old one:
User: admin.
User Display Name: admin.

The other one that can be also used is FAB manager. Available fields are:
- username
- first_name
- last_name
- email
- password
- role
- 
The common solution will be for different auth managers like this:

```For every audit log row:

   If first_name and last_name exist:
       show "first_name last_name"

   Else if email exists:
       show "email"

   Else:
       show "username"
```

Example:
first_name = Jane.
last_name = Smith.
email = [jane@example.com](mailto:jane@example.com).
username = jane.

User = jane.
User Display Name = Jane Smith.

Or:
first_name = empty.
last_name = empty.
email = [jane@example.com](mailto:jane@example.com).
username = jane.

User = jane.
User Display Name = [jane@example.com](mailto:jane@example.com).

This change will make the Audit log more informative for users. 
Example how it will look like:
<img width="898" height="692" alt="Screenshot 2026-06-17 at 12 53 38" src="https://github.com/user-attachments/assets/4d962b39-d917-48da-98d8-6503bf932488" />

The change is implemented as a new Column in Audit Logs tab, which can be also hidden in side menu by user, if preferred to not be shown.


 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #ISSUE
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [ ] Yes (please specify the tool below)

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
