### PR TITLE
FIX: Fixed bigquery_queries_async instability

### DIFF
--- a/task-sdk/src/airflow/sdk/execution_time/supervisor.py
+++ b/task-sdk/src/airflow/sdk/execution_time/supervisor.py
@@ -1616,18 +1616,18 @@ class ActivitySubprocess(WatchedSubprocess):
             self.failed_heartbeats = 0
         except ServerResponseError as e:
             if e.response.status_code in {HTTPStatus.NOT_FOUND, HTTPStatus.GONE, HTTPStatus.CONFLICT}:
-                log.error(
+                log.info(
                     "Server indicated the task shouldn't be running anymore",
                     detail=e.detail,
                     status_code=e.response.status_code,
                     ti_id=self.id,
                 )
-                self.process_log.error(
+                self.process_log.info(
                     "Server indicated the task shouldn't be running anymore. Terminating process",
                     detail=e.detail,
                 )
                 self.kill(signal.SIGTERM, force=True)
-                self.process_log.error("Task killed!")
+                self.process_log.info("Task killed!")
                 self._terminal_state = SERVER_TERMINATED
             else:
                 # If we get any other error, we'll just log it and try again next time
@@ -1687,9 +1687,9 @@ class ActivitySubprocess(WatchedSubprocess):
         dump_opts: dict[str, bool] = {}
         if isinstance(msg, TaskState):
             # No direct API call here — the recovery path in
-            # `update_task_state_if_needed` will call `finish()` for
             # non-direct states (FAILED, etc.) once the subprocess exits.
-            self._terminal_state = msg.state
+            if self._terminal_state != SERVER_TERMINATED:
+                self._terminal_state = msg.state
             self._task_end_time_monotonic = time.monotonic()
             self._rendered_map_index = msg.rendered_map_index
         elif isinstance(msg, SucceedTask):

--- a/task-sdk/src/airflow/sdk/execution_time/task_runner.py
+++ b/task-sdk/src/airflow/sdk/execution_time/task_runner.py
@@ -1542,6 +1542,7 @@ def run(
             return
 
         ti.task.on_kill()
+        raise AirflowTaskTerminated("Task received SIGTERM signal")
 
     signal.signal(signal.SIGTERM, _on_term)
 

--- a/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
+++ b/task-sdk/tests/task_sdk/execution_time/test_supervisor.py
@@ -891,7 +891,7 @@ class TestWatchedSubprocess:
             "loc": mocker.ANY,
         } in captured_logs
 
-    @pytest.mark.parametrize("captured_logs", [logging.ERROR], indirect=True, ids=["log_level=error"])
+    @pytest.mark.parametrize("captured_logs", [logging.INFO], indirect=True, ids=["log_level=info"])
     def test_state_conflict_on_heartbeat(self, captured_logs, monkeypatch, mocker, make_ti_context_dict):
         """
         Test that ensures that the Supervisor does not cause the task to fail if the Task Instance is no longer
@@ -961,7 +961,13 @@ class TestWatchedSubprocess:
 
         assert request_count["count"] == 2
         # Verify the error was logged
-        assert captured_logs == [
+        expected_events = {
+            "Server indicated the task shouldn't be running anymore",
+            "Server indicated the task shouldn't be running anymore. Terminating process",
+            "Task killed!",
+        }
+        filtered_logs = [log for log in captured_logs if log.get("event") in expected_events]
+        assert filtered_logs == [
             {
                 "detail": {
                     "reason": "not_running",
@@ -969,7 +975,7 @@ class TestWatchedSubprocess:
                     "current_state": "success",
                 },
                 "event": "Server indicated the task shouldn't be running anymore",
-                "level": "error",
+                "level": "info",
                 "status_code": 409,
                 "logger": "supervisor",
                 "timestamp": mocker.ANY,
@@ -983,14 +989,14 @@ class TestWatchedSubprocess:
                     "reason": "not_running",
                 },
                 "event": "Server indicated the task shouldn't be running anymore. Terminating process",
-                "level": "error",
+                "level": "info",
                 "logger": "task",
                 "timestamp": mocker.ANY,
                 "loc": mocker.ANY,
             },
             {
                 "event": "Task killed!",
-                "level": "error",
+                "level": "info",
                 "logger": "task",
                 "timestamp": mocker.ANY,
                 "loc": mocker.ANY,

--- a/uv.lock
+++ b/uv.lock
@@ -968,7 +968,7 @@ wheels = [
 
 [[package]]
 name = "apache-airflow"
-version = "3.3.0"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "apache-airflow-core" },
@@ -1911,7 +1911,7 @@ requires-dist = [
 
 [[package]]
 name = "apache-airflow-core"
-version = "3.3.0"
+version = "3.4.0"
 source = { editable = "airflow-core" }
 dependencies = [
     { name = "a2wsgi" },


### PR DESCRIPTION
 <!-- SPDX-License-Identifier: Apache-2.0
      https://www.apache.org/licenses/LICENSE-2.0 -->

This PR fixes the unstability for bigquery_queries_async system test on Dashboard and locally

**The Problem:**
The bug occurs during task cancellation/teardown in Airflow 3. When an external entity (like the Web UI or an integration test suite during teardown) deletes or clears the Task Instance from the database while the task is still running:
1. The heartbeat request from the Supervisor returns a 404 Not Found or 409 Conflict.
1. The Supervisor attempts to gracefully terminate the task process by sending a SIGTERM signal.
1. The Bug: task_runner.py's signal handler (_on_term) executed the task's on_kill() callbacks but failed to actually exit the process or raise a termination exception. As a result, the task kept running indefinitely.
1. The Escalation: The Supervisor, after waiting the escalation_delay (exactly 5.0 seconds as seen in your logs), forcibly sent SIGKILL (-9).
1. The Side Effects: The -9 exit code corrupted the Supervisor's final interpretation of the task state. In addition, the Supervisor incorrectly logged the 404/409 not_found / not_running events as ERRORs rather than expected lifecycle events, which triggered failure conditions in tests that assert for clean logs.

**Solution:**

1. Updated _on_term (the SIGTERM handler) to raise an AirflowTaskTerminated("Task received SIGTERM signal") exception instead of swallowing the signal. This ensures the task process unwinds its stack, triggers context manager cleanup, and exits gracefully before the supervisor has to escalate to SIGKILL.
1. Changed the log levels for 404/409 HTTP errors and the "Server indicated the task shouldn't be running anymore" messages from error to info. This treats tasks being manually cleared or deleted by test teardowns as a routine, non-fatal event, eliminating log pollution.
1. Added a state guard (if self._terminal_state != SERVER_TERMINATED:) when receiving TaskState messages to prevent late or delayed state messages from the child process overwriting a terminal state generated by the supervisor itself.
1. Updated the test_state_conflict_on_heartbeat unit test's parameters and assertions to expect "level": "info" instead of "level": "error", ensuring alignment with the fixes.

<!--
Thank you for contributing!

Please provide above a brief description of the changes made in this pull request.
Write a good git commit message following this guide: http://chris.beams.io/posts/git-commit/

Please make sure that your code changes are covered with tests.
And in case of new features or big changes remember to adjust the documentation.

For user-facing UI changes, please attach before/after screenshots (or a short
screen recording) so reviewers can assess the visual impact.

Feel free to ping (in general) for the review if you do not see reaction for a few days
(72 Hours is the minimum reaction time you can expect from volunteers) - we sometimes miss notifications.

In case of an existing issue, reference it using one of the following:

* closes: #514597630
* related: #ISSUE
-->

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [X] Yes (please specify the tool below)
JetSki

<!--
Generated-by: [Tool Name] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---

* Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information. Note: commit author/co-author name and email in commits become permanently public when merged.
* For fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
* When adding dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
* For significant user-facing changes create newsfragment: `{pr_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments). You can add this file in a follow-up commit after the PR is created so you know the PR number.
