### PR TITLE
Keep fernet key env variable if defined while running pytest

### DIFF
--- a/devel-common/src/tests_common/pytest_plugin.py
+++ b/devel-common/src/tests_common/pytest_plugin.py
@@ -94,7 +94,7 @@ if not keep_env_variables:
         # Keep always these configurations
         "always": {
             "database": {"sql_alchemy_conn"},
-            "core": {"sql_alchemy_conn"},
+            "core": {"sql_alchemy_conn", "fernet_key"},
             "celery": {"result_backend", "broker_url"},
         },
         # Keep per enabled integrations


### PR DESCRIPTION
When running `breeze testing system-tests`, the api server is started before the `pytest`. Currently they share the same sql_alchemy_conn, but they use different fernet key.

Some system tests, such as `providers/google/tests/system/google/cloud/gcs/example_gdrive_to_gcs.py`, first create a connection using the API server and then try to use it. If there is any extra data passed, it will be encrypted using one fernet key (used by the API server) and the attempt to decrypt will be made using pytest fernet key.

Rationale of this change is that if without `--keep-env-variables` sql_alchemy_conn is kept, then the fernet key should also be kept.

For this fix to work, the user needs to set `AIRFLOW__CORE__FERNET_KEY` in their environment. It would probably be nicer if the breeze testing script set it up automatically just like it sets sqlalchemy connection string.

